### PR TITLE
Add database abstraction design baseline

### DIFF
--- a/.github/workflows/db-engine-validation.yml
+++ b/.github/workflows/db-engine-validation.yml
@@ -1,0 +1,46 @@
+name: Database Engine Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "packages/db-abstraction/**"
+      - "migrations/**"
+      - ".github/workflows/db-engine-validation.yml"
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "packages/db-abstraction/**"
+      - "migrations/**"
+      - ".github/workflows/db-engine-validation.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-engine-layout:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [postgres, mssql, mariadb]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate abstraction package
+        run: npm run db:validate
+
+      - name: Confirm engine directory
+        run: test -d migrations/${{ matrix.engine }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ InfraLynx application monorepo for product runtime code, shared libraries, test 
 - `apps/api` for the HTTP API service
 - `apps/worker` for background jobs and asynchronous processing
 - `packages/config` for shared configuration helpers
+- `packages/db-abstraction` for database capability mapping and migration contracts
 - `packages/domain-core` for core platform contracts and boundaries
 - `packages/shared` for cross-cutting utilities that are safe to reuse
 - `tests` for cross-workspace test organization
@@ -16,4 +17,4 @@ InfraLynx application monorepo for product runtime code, shared libraries, test 
 
 ## Current Status
 
-Chunk 4 establishes the monorepo foundation only. It provides a buildable TypeScript workspace structure and explicit domain separation without starting feature implementation.
+The current baseline includes CI validation and database-abstraction design scaffolding, but does not yet implement runtime data access or engine-specific drivers.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,9 +1,16 @@
-# Migrations
+# Database Migrations
 
-This directory will hold engine-aware migration assets for:
+InfraLynx stores schema changes per supported engine so version intent stays aligned even when SQL differs.
 
-- PostgreSQL
-- Microsoft SQL Server
-- MariaDB
+## Engine Directories
 
-Migration implementation is deferred until the database compatibility foundation chunk.
+- `migrations/postgres`
+- `migrations/mssql`
+- `migrations/mariadb`
+
+## Rules
+
+- version numbers must stay aligned across engines
+- reference behavior is designed against PostgreSQL first
+- engine-specific SQL must be isolated to engine directories
+- unsupported features must be documented before they are used

--- a/migrations/mariadb/README.md
+++ b/migrations/mariadb/README.md
@@ -1,3 +1,5 @@
 # MariaDB Migrations
 
-Reserved for MariaDB migration scripts and execution support files.
+This directory contains MariaDB-specific migration variants aligned to the shared InfraLynx migration version stream.
+
+Schema changes must be written defensively where DDL rollback or JSON semantics differ from the PostgreSQL reference engine.

--- a/migrations/mssql/README.md
+++ b/migrations/mssql/README.md
@@ -1,0 +1,5 @@
+# Microsoft SQL Server Migrations
+
+This directory contains SQL Server-specific migration variants aligned to the shared InfraLynx migration version stream.
+
+Document every behavioral deviation from the PostgreSQL reference migration before implementation.

--- a/migrations/postgres/README.md
+++ b/migrations/postgres/README.md
@@ -1,0 +1,5 @@
+# PostgreSQL Migrations
+
+PostgreSQL is the reference engine for InfraLynx schema behavior.
+
+Use this directory for PostgreSQL-specific SQL and migration manifests that define the canonical version path for other engines to follow.

--- a/migrations/postgresql/README.md
+++ b/migrations/postgresql/README.md
@@ -1,3 +1,0 @@
-# PostgreSQL Migrations
-
-Reserved for PostgreSQL migration scripts and execution support files.

--- a/migrations/sqlserver/README.md
+++ b/migrations/sqlserver/README.md
@@ -1,3 +1,0 @@
-# SQL Server Migrations
-
-Reserved for Microsoft SQL Server migration scripts and execution support files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,6 +263,10 @@
       "resolved": "packages/config",
       "link": true
     },
+    "node_modules/@infralynx/db-abstraction": {
+      "resolved": "packages/db-abstraction",
+      "link": true
+    },
     "node_modules/@infralynx/domain-core": {
       "resolved": "packages/domain-core",
       "link": true
@@ -1538,6 +1542,10 @@
     },
     "packages/config": {
       "name": "@infralynx/config",
+      "version": "0.1.0"
+    },
+    "packages/db-abstraction": {
+      "name": "@infralynx/db-abstraction",
       "version": "0.1.0"
     },
     "packages/domain-core": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
   "scripts": {
     "build": "npm run clean && npm run build:packages && npm run build:apps",
     "build:apps": "tsc -p apps/api/tsconfig.json && tsc -p apps/worker/tsconfig.json && tsc -p apps/web/tsconfig.json",
-    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/shared/tsconfig.json",
+    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/shared/tsconfig.json",
     "clean": "node scripts/clean.mjs",
+    "db:validate": "node scripts/validate-db-layout.mjs",
     "lint": "eslint . --ext .ts,.mjs --max-warnings=0",
     "pretest": "npm run clean && npm run build:packages",
     "test": "node --test tests/unit/**/*.test.mjs",
     "typecheck": "npm run clean && npm run build:packages && npm run typecheck:apps && npm run typecheck:packages",
     "typecheck:apps": "tsc -p apps/api/tsconfig.json --noEmit --pretty false && tsc -p apps/worker/tsconfig.json --noEmit --pretty false && tsc -p apps/web/tsconfig.json --noEmit --pretty false",
-    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
+    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/packages/db-abstraction/package.json
+++ b/packages/db-abstraction/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@infralynx/db-abstraction",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/db-abstraction/src/index.ts
+++ b/packages/db-abstraction/src/index.ts
@@ -1,0 +1,127 @@
+export type DatabaseEngine = "postgres" | "mssql" | "mariadb";
+
+export type CapabilityStatus = "native" | "emulated" | "restricted";
+
+export interface EngineCapability {
+  readonly capability: string;
+  readonly status: CapabilityStatus;
+  readonly notes: string;
+}
+
+export interface EngineProfile {
+  readonly engine: DatabaseEngine;
+  readonly reference: boolean;
+  readonly parameterStyle: string;
+  readonly identifierQuoting: string;
+  readonly migrationDirectory: string;
+  readonly capabilities: readonly EngineCapability[];
+}
+
+export interface MigrationRule {
+  readonly rule: string;
+  readonly rationale: string;
+}
+
+export const engineProfiles: readonly EngineProfile[] = [
+  {
+    engine: "postgres",
+    reference: true,
+    parameterStyle: "positional ($1, $2, ...)",
+    identifierQuoting: "double quotes",
+    migrationDirectory: "migrations/postgres",
+    capabilities: [
+      {
+        capability: "transactional-ddl",
+        status: "native",
+        notes: "Default reference behavior for schema changes."
+      },
+      {
+        capability: "json-document-columns",
+        status: "native",
+        notes: "Use as the canonical JSON capability for abstraction design."
+      },
+      {
+        capability: "generated-columns",
+        status: "native",
+        notes: "Available directly but must stay abstracted behind capability flags."
+      }
+    ]
+  },
+  {
+    engine: "mssql",
+    reference: false,
+    parameterStyle: "named (@p1, @p2, ...)",
+    identifierQuoting: "square brackets",
+    migrationDirectory: "migrations/mssql",
+    capabilities: [
+      {
+        capability: "transactional-ddl",
+        status: "restricted",
+        notes: "Migration steps must model DDL transaction limitations explicitly."
+      },
+      {
+        capability: "json-document-columns",
+        status: "emulated",
+        notes: "JSON support is expression-based rather than a dedicated JSON type."
+      },
+      {
+        capability: "generated-columns",
+        status: "native",
+        notes: "Computed columns exist but semantics differ from PostgreSQL."
+      }
+    ]
+  },
+  {
+    engine: "mariadb",
+    reference: false,
+    parameterStyle: "positional (?)",
+    identifierQuoting: "backticks",
+    migrationDirectory: "migrations/mariadb",
+    capabilities: [
+      {
+        capability: "transactional-ddl",
+        status: "restricted",
+        notes: "Assume partial rollback semantics for DDL and design migrations defensively."
+      },
+      {
+        capability: "json-document-columns",
+        status: "emulated",
+        notes: "JSON storage semantics differ from PostgreSQL and must not be assumed equivalent."
+      },
+      {
+        capability: "generated-columns",
+        status: "native",
+        notes: "Supported with engine-specific syntax differences."
+      }
+    ]
+  }
+] as const;
+
+export const migrationRules: readonly MigrationRule[] = [
+  {
+    rule: "Author every migration against the shared abstraction contract first.",
+    rationale: "Reference-engine SQL cannot be treated as portable implementation by default."
+  },
+  {
+    rule: "Store migrations per engine in parallel version directories.",
+    rationale: "Version alignment must remain explicit even when SQL differs by dialect."
+  },
+  {
+    rule: "Declare capability assumptions before using JSON, computed columns, or engine functions.",
+    rationale: "Cross-engine drift is usually hidden in advanced schema features."
+  },
+  {
+    rule: "Keep destructive and irreversible changes isolated from mixed-purpose migrations.",
+    rationale: "Rollback and safety characteristics vary materially between supported engines."
+  }
+] as const;
+
+export function getEngineProfile(engine: DatabaseEngine): EngineProfile {
+  const profile = engineProfiles.find((entry) => entry.engine === engine);
+
+  if (!profile) {
+    throw new Error(`Unsupported database engine: ${engine}`);
+  }
+
+  return profile;
+}

--- a/packages/db-abstraction/tsconfig.json
+++ b/packages/db-abstraction/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -9,6 +9,8 @@ const paths = [
   "apps/worker/tsconfig.tsbuildinfo",
   "packages/config/dist",
   "packages/config/tsconfig.tsbuildinfo",
+  "packages/db-abstraction/dist",
+  "packages/db-abstraction/tsconfig.tsbuildinfo",
   "packages/domain-core/dist",
   "packages/domain-core/tsconfig.tsbuildinfo",
   "packages/shared/dist",

--- a/scripts/validate-db-layout.mjs
+++ b/scripts/validate-db-layout.mjs
@@ -1,0 +1,25 @@
+import { existsSync, readFileSync } from "node:fs";
+
+const engines = ["postgres", "mssql", "mariadb"];
+
+const packageJsonPath = "packages/db-abstraction/package.json";
+
+if (!existsSync(packageJsonPath)) {
+  throw new Error("Missing packages/db-abstraction/package.json");
+}
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+
+if (packageJson.name !== "@infralynx/db-abstraction") {
+  throw new Error("Database abstraction package name is not aligned with the workspace contract.");
+}
+
+for (const engine of engines) {
+  const path = `migrations/${engine}`;
+
+  if (!existsSync(path)) {
+    throw new Error(`Missing migration directory: ${path}`);
+  }
+}
+
+console.log("Database abstraction layout is valid for postgres, mssql, and mariadb.");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./packages/config" },
+    { "path": "./packages/db-abstraction" },
     { "path": "./packages/domain-core" },
     { "path": "./packages/shared" },
     { "path": "./apps/api" },


### PR DESCRIPTION
## Summary
- add the initial db-abstraction package and migration layout
- document supported engine capabilities and migration rules
- add a database engine validation workflow for postgres, mssql, and mariadb

## Validation
- npm run db:validate
- npm run lint
- npm run typecheck
- npm run build
- npm test