### PR TITLE
Add IPAM domain design scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ InfraLynx application monorepo for product runtime code, shared libraries, test 
 - `packages/audit` for audit record contracts and append-only event helpers
 - `packages/db-abstraction` for database capability mapping and migration contracts
 - `packages/domain-core` for core platform contracts and boundaries
+- `packages/ipam-domain` for VRF, prefix, IP address, VLAN, and allocation contracts
 - `packages/shared` for cross-cutting utilities that are safe to reuse
 - `tests` for cross-workspace test organization
 - `migrations` for database-engine migration structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,10 @@
       "resolved": "packages/domain-core",
       "link": true
     },
+    "node_modules/@infralynx/ipam-domain": {
+      "resolved": "packages/ipam-domain",
+      "link": true
+    },
     "node_modules/@infralynx/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -1574,6 +1578,10 @@
     },
     "packages/domain-core": {
       "name": "@infralynx/domain-core",
+      "version": "0.1.0"
+    },
+    "packages/ipam-domain": {
+      "name": "@infralynx/ipam-domain",
       "version": "0.1.0"
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:packages && npm run build:apps",
     "build:apps": "tsc -p apps/api/tsconfig.json && tsc -p apps/worker/tsconfig.json && tsc -p apps/web/tsconfig.json",
-    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/shared/tsconfig.json",
+    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/ipam-domain/tsconfig.json && tsc -p packages/shared/tsconfig.json",
     "clean": "node scripts/clean.mjs",
     "db:validate": "node scripts/validate-db-layout.mjs",
     "lint": "eslint . --ext .ts,.mjs --max-warnings=0",
@@ -19,7 +19,7 @@
     "test": "node --test tests/unit/**/*.test.mjs",
     "typecheck": "npm run clean && npm run build:packages && npm run typecheck:apps && npm run typecheck:packages",
     "typecheck:apps": "tsc -p apps/api/tsconfig.json --noEmit --pretty false && tsc -p apps/worker/tsconfig.json --noEmit --pretty false && tsc -p apps/web/tsconfig.json --noEmit --pretty false",
-    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
+    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/ipam-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/packages/ipam-domain/package.json
+++ b/packages/ipam-domain/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@infralynx/ipam-domain",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/ipam-domain/src/index.ts
+++ b/packages/ipam-domain/src/index.ts
@@ -1,0 +1,153 @@
+export type AddressFamily = 4 | 6;
+
+export type AllocationMode = "hierarchical" | "pool" | "static";
+
+export interface Vrf {
+  readonly id: string;
+  readonly name: string;
+  readonly rd: string | null;
+  readonly tenantId: string | null;
+}
+
+export interface Prefix {
+  readonly id: string;
+  readonly vrfId: string | null;
+  readonly cidr: string;
+  readonly family: AddressFamily;
+  readonly status: "active" | "reserved" | "deprecated";
+  readonly allocationMode: AllocationMode;
+  readonly tenantId: string | null;
+  readonly vlanId: string | null;
+}
+
+export interface IpAddress {
+  readonly id: string;
+  readonly vrfId: string | null;
+  readonly address: string;
+  readonly family: AddressFamily;
+  readonly status: "active" | "reserved" | "deprecated";
+  readonly role: "loopback" | "primary" | "secondary" | "vip";
+  readonly prefixId: string | null;
+}
+
+export interface Vlan {
+  readonly id: string;
+  readonly vlanId: number;
+  readonly name: string;
+  readonly status: "active" | "reserved" | "deprecated";
+  readonly tenantId: string | null;
+}
+
+export interface AllocationRequest {
+  readonly parentPrefix: Prefix;
+  readonly childCidr: string;
+  readonly childFamily: AddressFamily;
+  readonly childVrfId: string | null;
+}
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly reason: string;
+}
+
+export const ipamStatusSet = ["active", "reserved", "deprecated"] as const;
+
+export function isValidVlanId(vlanId: number): boolean {
+  return Number.isInteger(vlanId) && vlanId >= 1 && vlanId <= 4094;
+}
+
+export function isValidRouteDistinguisher(rd: string | null): boolean {
+  if (rd === null) {
+    return true;
+  }
+
+  return /^[0-9]+:[0-9]+$/.test(rd);
+}
+
+export function parseCidr(cidr: string): { network: string; prefixLength: number } | null {
+  const [network, prefixLength] = cidr.split("/");
+
+  if (!network || prefixLength === undefined) {
+    return null;
+  }
+
+  const parsedPrefixLength = Number(prefixLength);
+
+  if (!Number.isInteger(parsedPrefixLength)) {
+    return null;
+  }
+
+  return {
+    network,
+    prefixLength: parsedPrefixLength
+  };
+}
+
+export function isValidPrefixLength(family: AddressFamily, prefixLength: number): boolean {
+  if (!Number.isInteger(prefixLength)) {
+    return false;
+  }
+
+  return family === 4
+    ? prefixLength >= 0 && prefixLength <= 32
+    : prefixLength >= 0 && prefixLength <= 128;
+}
+
+export function validatePrefix(prefix: Prefix): ValidationResult {
+  const parsed = parseCidr(prefix.cidr);
+
+  if (!parsed) {
+    return { valid: false, reason: "cidr must use network/prefix-length format" };
+  }
+
+  if (!isValidPrefixLength(prefix.family, parsed.prefixLength)) {
+    return { valid: false, reason: "prefix length is outside valid family bounds" };
+  }
+
+  return { valid: true, reason: "prefix shape is valid" };
+}
+
+export function validateIpAddress(ipAddress: IpAddress): ValidationResult {
+  if (!ipAddress.address.includes("/")) {
+    return { valid: false, reason: "ip address must include host prefix length" };
+  }
+
+  const parsed = parseCidr(ipAddress.address);
+
+  if (!parsed || !isValidPrefixLength(ipAddress.family, parsed.prefixLength)) {
+    return { valid: false, reason: "ip address prefix length is outside valid family bounds" };
+  }
+
+  return { valid: true, reason: "ip address shape is valid" };
+}
+
+export function canAllocateChildPrefix(request: AllocationRequest): ValidationResult {
+  const parentCidr = parseCidr(request.parentPrefix.cidr);
+  const childCidr = parseCidr(request.childCidr);
+
+  if (!parentCidr || !childCidr) {
+    return { valid: false, reason: "parent and child prefixes must both be valid CIDRs" };
+  }
+
+  if (request.parentPrefix.family !== request.childFamily) {
+    return { valid: false, reason: "child prefix must stay within the same address family" };
+  }
+
+  if (request.parentPrefix.vrfId !== request.childVrfId) {
+    return { valid: false, reason: "child prefix must stay within the same VRF" };
+  }
+
+  if (childCidr.prefixLength <= parentCidr.prefixLength) {
+    return { valid: false, reason: "child prefix must be more specific than the parent prefix" };
+  }
+
+  if (request.parentPrefix.status !== "active") {
+    return { valid: false, reason: "allocation can only occur from active parent prefixes" };
+  }
+
+  return { valid: true, reason: "child prefix request satisfies baseline allocation rules" };
+}
+
+export function createVlanDirectory(vlans: readonly Vlan[]) {
+  return new Map(vlans.map((vlan) => [vlan.vlanId, vlan]));
+}

--- a/packages/ipam-domain/tsconfig.json
+++ b/packages/ipam-domain/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -19,6 +19,8 @@ const paths = [
   "packages/db-abstraction/tsconfig.tsbuildinfo",
   "packages/domain-core/dist",
   "packages/domain-core/tsconfig.tsbuildinfo",
+  "packages/ipam-domain/dist",
+  "packages/ipam-domain/tsconfig.tsbuildinfo",
   "packages/shared/dist",
   "packages/shared/tsconfig.tsbuildinfo"
 ];

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -10,6 +10,14 @@ import {
 } from "../../packages/core-domain/dist/index.js";
 import { createSession, resolveAccessDecision } from "../../packages/auth/dist/index.js";
 import { createAuditRecord, summarizeAuditRecord } from "../../packages/audit/dist/index.js";
+import {
+  canAllocateChildPrefix,
+  createVlanDirectory,
+  isValidRouteDistinguisher,
+  isValidVlanId,
+  validateIpAddress,
+  validatePrefix
+} from "../../packages/ipam-domain/dist/index.js";
 import { coreDomains, platformBoundaries } from "../../packages/domain-core/dist/index.js";
 import { formatBanner } from "../../packages/shared/dist/index.js";
 
@@ -79,4 +87,51 @@ test("audit scaffolds create append-only summaries", () => {
     summarizeAuditRecord(record),
     "2026-03-26T00:00:00.000Z authentication:session.created by user"
   );
+});
+
+test("ipam scaffolds validate basic VRF, prefix, IP, and VLAN rules", () => {
+  const prefixValidation = validatePrefix({
+    id: "prefix-1",
+    vrfId: "vrf-1",
+    cidr: "10.0.0.0/24",
+    family: 4,
+    status: "active",
+    allocationMode: "hierarchical",
+    tenantId: "tenant-1",
+    vlanId: "vlan-1"
+  });
+  const addressValidation = validateIpAddress({
+    id: "ip-1",
+    vrfId: "vrf-1",
+    address: "10.0.0.10/24",
+    family: 4,
+    status: "active",
+    role: "primary",
+    prefixId: "prefix-1"
+  });
+  const allocationDecision = canAllocateChildPrefix({
+    parentPrefix: {
+      id: "prefix-1",
+      vrfId: "vrf-1",
+      cidr: "10.0.0.0/24",
+      family: 4,
+      status: "active",
+      allocationMode: "hierarchical",
+      tenantId: "tenant-1",
+      vlanId: null
+    },
+    childCidr: "10.0.0.0/28",
+    childFamily: 4,
+    childVrfId: "vrf-1"
+  });
+  const vlanDirectory = createVlanDirectory([
+    { id: "vlan-1", vlanId: 120, name: "Servers", status: "active", tenantId: "tenant-1" }
+  ]);
+
+  assert.equal(prefixValidation.valid, true);
+  assert.equal(addressValidation.valid, true);
+  assert.equal(allocationDecision.valid, true);
+  assert.equal(vlanDirectory.get(120)?.name, "Servers");
+  assert.equal(isValidVlanId(4094), true);
+  assert.equal(isValidRouteDistinguisher("65000:10"), true);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "./packages/audit" },
     { "path": "./packages/db-abstraction" },
     { "path": "./packages/domain-core" },
+    { "path": "./packages/ipam-domain" },
     { "path": "./packages/shared" },
     { "path": "./apps/api" },
     { "path": "./apps/worker" },


### PR DESCRIPTION
## Summary
- add the ipam-domain package for VRFs, prefixes, IP addresses, and VLANs
- scaffold baseline validation and allocation policy helpers
- extend unit coverage and workspace package build order

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test