### PR TITLE
Add DCIM domain design scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ InfraLynx application monorepo for product runtime code, shared libraries, test 
 - `packages/auth` for authentication sessions and authorization policy scaffolds
 - `packages/audit` for audit record contracts and append-only event helpers
 - `packages/db-abstraction` for database capability mapping and migration contracts
+- `packages/dcim-domain` for physical infrastructure, rack, interface, power, and cabling contracts
 - `packages/domain-core` for core platform contracts and boundaries
 - `packages/ipam-domain` for VRF, prefix, IP address, VLAN, and allocation contracts
 - `packages/shared` for cross-cutting utilities that are safe to reuse

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,6 +279,10 @@
       "resolved": "packages/db-abstraction",
       "link": true
     },
+    "node_modules/@infralynx/dcim-domain": {
+      "resolved": "packages/dcim-domain",
+      "link": true
+    },
     "node_modules/@infralynx/domain-core": {
       "resolved": "packages/domain-core",
       "link": true
@@ -1574,6 +1578,10 @@
     },
     "packages/db-abstraction": {
       "name": "@infralynx/db-abstraction",
+      "version": "0.1.0"
+    },
+    "packages/dcim-domain": {
+      "name": "@infralynx/dcim-domain",
       "version": "0.1.0"
     },
     "packages/domain-core": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:packages && npm run build:apps",
     "build:apps": "tsc -p apps/api/tsconfig.json && tsc -p apps/worker/tsconfig.json && tsc -p apps/web/tsconfig.json",
-    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/ipam-domain/tsconfig.json && tsc -p packages/shared/tsconfig.json",
+    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/dcim-domain/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/ipam-domain/tsconfig.json && tsc -p packages/shared/tsconfig.json",
     "clean": "node scripts/clean.mjs",
     "db:validate": "node scripts/validate-db-layout.mjs",
     "lint": "eslint . --ext .ts,.mjs --max-warnings=0",
@@ -19,7 +19,7 @@
     "test": "node --test tests/unit/**/*.test.mjs",
     "typecheck": "npm run clean && npm run build:packages && npm run typecheck:apps && npm run typecheck:packages",
     "typecheck:apps": "tsc -p apps/api/tsconfig.json --noEmit --pretty false && tsc -p apps/worker/tsconfig.json --noEmit --pretty false && tsc -p apps/web/tsconfig.json --noEmit --pretty false",
-    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/ipam-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
+    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/dcim-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/ipam-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/packages/dcim-domain/package.json
+++ b/packages/dcim-domain/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@infralynx/dcim-domain",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/dcim-domain/src/index.ts
+++ b/packages/dcim-domain/src/index.ts
@@ -1,0 +1,132 @@
+export type DeviceRole = "server" | "switch" | "router" | "pdu" | "appliance";
+export type RackFace = "front" | "rear";
+export type InterfaceKind = "ethernet" | "fiber" | "management" | "console";
+export type PowerFeedKind = "ac" | "dc";
+export type CableKind = "data" | "power" | "console";
+
+export interface Site {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly tenantId: string | null;
+}
+
+export interface Rack {
+  readonly id: string;
+  readonly siteId: string;
+  readonly name: string;
+  readonly totalUnits: number;
+}
+
+export interface RackPosition {
+  readonly rackId: string;
+  readonly face: RackFace;
+  readonly startingUnit: number;
+  readonly heightUnits: number;
+}
+
+export interface Device {
+  readonly id: string;
+  readonly siteId: string;
+  readonly rackPosition: RackPosition | null;
+  readonly name: string;
+  readonly role: DeviceRole;
+  readonly status: "active" | "planned" | "offline" | "decommissioned";
+}
+
+export interface Interface {
+  readonly id: string;
+  readonly deviceId: string;
+  readonly name: string;
+  readonly kind: InterfaceKind;
+  readonly enabled: boolean;
+}
+
+export interface PowerPort {
+  readonly id: string;
+  readonly deviceId: string;
+  readonly name: string;
+  readonly feedKind: PowerFeedKind;
+}
+
+export interface CableEndpoint {
+  readonly deviceId: string;
+  readonly portId: string;
+}
+
+export interface Cable {
+  readonly id: string;
+  readonly kind: CableKind;
+  readonly aSide: CableEndpoint;
+  readonly zSide: CableEndpoint;
+  readonly status: "connected" | "planned" | "decommissioned";
+}
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly reason: string;
+}
+
+export function isValidRackUnit(totalUnits: number, unit: number): boolean {
+  return Number.isInteger(totalUnits) && totalUnits > 0 && Number.isInteger(unit) && unit >= 1 && unit <= totalUnits;
+}
+
+export function validateRackPosition(rack: Rack, position: RackPosition): ValidationResult {
+  if (position.rackId !== rack.id) {
+    return { valid: false, reason: "rack position must reference the same rack" };
+  }
+
+  if (!isValidRackUnit(rack.totalUnits, position.startingUnit)) {
+    return { valid: false, reason: "starting rack unit is outside rack bounds" };
+  }
+
+  if (!Number.isInteger(position.heightUnits) || position.heightUnits < 1) {
+    return { valid: false, reason: "device height must be at least 1U" };
+  }
+
+  const endingUnit = position.startingUnit + position.heightUnits - 1;
+
+  if (!isValidRackUnit(rack.totalUnits, endingUnit)) {
+    return { valid: false, reason: "device height extends beyond rack capacity" };
+  }
+
+  return { valid: true, reason: "rack position is valid" };
+}
+
+export function canOccupyRackPosition(
+  rack: Rack,
+  candidate: RackPosition,
+  occupied: readonly RackPosition[]
+): ValidationResult {
+  const positionValidation = validateRackPosition(rack, candidate);
+
+  if (!positionValidation.valid) {
+    return positionValidation;
+  }
+
+  for (const position of occupied) {
+    const sameRack = position.rackId === candidate.rackId;
+    const sameFace = position.face === candidate.face;
+    const overlaps =
+      candidate.startingUnit <= position.startingUnit + position.heightUnits - 1 &&
+      position.startingUnit <= candidate.startingUnit + candidate.heightUnits - 1;
+
+    if (sameRack && sameFace && overlaps) {
+      return { valid: false, reason: "rack position overlaps an existing device on the same face" };
+    }
+  }
+
+  return { valid: true, reason: "rack position does not overlap existing devices" };
+}
+
+export function validateCable(cable: Cable): ValidationResult {
+  if (cable.aSide.deviceId === cable.zSide.deviceId && cable.aSide.portId === cable.zSide.portId) {
+    return { valid: false, reason: "cable endpoints must not reference the same port" };
+  }
+
+  return { valid: true, reason: "cable endpoints are distinct" };
+}
+
+export function createRackDirectory(racks: readonly Rack[]) {
+  return new Map(racks.map((rack) => [rack.id, rack]));
+}

--- a/packages/dcim-domain/tsconfig.json
+++ b/packages/dcim-domain/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -17,6 +17,8 @@ const paths = [
   "packages/audit/tsconfig.tsbuildinfo",
   "packages/db-abstraction/dist",
   "packages/db-abstraction/tsconfig.tsbuildinfo",
+  "packages/dcim-domain/dist",
+  "packages/dcim-domain/tsconfig.tsbuildinfo",
   "packages/domain-core/dist",
   "packages/domain-core/tsconfig.tsbuildinfo",
   "packages/ipam-domain/dist",
@@ -26,5 +28,19 @@ const paths = [
 ];
 
 for (const path of paths) {
-  rmSync(path, { force: true, recursive: true });
+  try {
+    rmSync(path, {
+      force: true,
+      recursive: true,
+      maxRetries: 3,
+      retryDelay: 100
+    });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "EPERM") {
+      // Windows can briefly hold generated files open; ignore transient cleanup locks.
+      continue;
+    }
+
+    throw error;
+  }
 }

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -11,6 +11,12 @@ import {
 import { createSession, resolveAccessDecision } from "../../packages/auth/dist/index.js";
 import { createAuditRecord, summarizeAuditRecord } from "../../packages/audit/dist/index.js";
 import {
+  canOccupyRackPosition,
+  createRackDirectory,
+  validateCable,
+  validateRackPosition
+} from "../../packages/dcim-domain/dist/index.js";
+import {
   canAllocateChildPrefix,
   createVlanDirectory,
   isValidRouteDistinguisher,
@@ -134,4 +140,49 @@ test("ipam scaffolds validate basic VRF, prefix, IP, and VLAN rules", () => {
   assert.equal(vlanDirectory.get(120)?.name, "Servers");
   assert.equal(isValidVlanId(4094), true);
   assert.equal(isValidRouteDistinguisher("65000:10"), true);
+});
+
+test("dcim scaffolds validate rack occupancy and cable endpoints", () => {
+  const rack = {
+    id: "rack-1",
+    siteId: "site-1",
+    name: "R1",
+    totalUnits: 42
+  };
+  const rackValidation = validateRackPosition(rack, {
+    rackId: "rack-1",
+    face: "front",
+    startingUnit: 10,
+    heightUnits: 2
+  });
+  const occupancyDecision = canOccupyRackPosition(
+    rack,
+    {
+      rackId: "rack-1",
+      face: "front",
+      startingUnit: 10,
+      heightUnits: 2
+    },
+    [
+      {
+        rackId: "rack-1",
+        face: "rear",
+        startingUnit: 10,
+        heightUnits: 2
+      }
+    ]
+  );
+  const cableValidation = validateCable({
+    id: "cable-1",
+    kind: "data",
+    aSide: { deviceId: "device-1", portId: "eth0" },
+    zSide: { deviceId: "device-2", portId: "eth1" },
+    status: "connected"
+  });
+  const rackDirectory = createRackDirectory([rack]);
+
+  assert.equal(rackValidation.valid, true);
+  assert.equal(occupancyDecision.valid, true);
+  assert.equal(cableValidation.valid, true);
+  assert.equal(rackDirectory.get("rack-1")?.name, "R1");
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./packages/auth" },
     { "path": "./packages/audit" },
     { "path": "./packages/db-abstraction" },
+    { "path": "./packages/dcim-domain" },
     { "path": "./packages/domain-core" },
     { "path": "./packages/ipam-domain" },
     { "path": "./packages/shared" },


### PR DESCRIPTION
## Summary
- add the dcim-domain package for sites, racks, devices, interfaces, power, and cabling
- scaffold rack-position, occupancy, and cable validation helpers
- extend unit coverage and workspace package build order

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test