### PR TITLE
Add cross-domain integration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ InfraLynx application monorepo for product runtime code, shared libraries, test 
 - `packages/dcim-domain` for physical infrastructure, rack, interface, power, and cabling contracts
 - `packages/domain-core` for core platform contracts and boundaries
 - `packages/ipam-domain` for VRF, prefix, IP address, VLAN, and allocation contracts
+- `packages/network-domain` for explicit bindings across interfaces, IPs, VLANs, cables, and prefix hierarchy
 - `packages/ui` for shell navigation, tokens, and shared frontend composition contracts
 - `packages/shared` for cross-cutting utilities that are safe to reuse
 - `tests` for cross-workspace test organization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,6 +1044,10 @@
       "resolved": "packages/ipam-domain",
       "link": true
     },
+    "node_modules/@infralynx/network-domain": {
+      "resolved": "packages/network-domain",
+      "link": true
+    },
     "node_modules/@infralynx/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -3355,6 +3359,10 @@
     },
     "packages/ipam-domain": {
       "name": "@infralynx/ipam-domain",
+      "version": "0.1.0"
+    },
+    "packages/network-domain": {
+      "name": "@infralynx/network-domain",
       "version": "0.1.0"
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:packages && npm run build:apps",
     "build:apps": "tsc -p apps/api/tsconfig.json && tsc -p apps/worker/tsconfig.json && npm --workspace @infralynx/web run build",
-    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/dcim-domain/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/ipam-domain/tsconfig.json && tsc -p packages/ui/tsconfig.json && tsc -p packages/shared/tsconfig.json",
+    "build:packages": "tsc -p packages/config/tsconfig.json && tsc -p packages/core-domain/tsconfig.json && tsc -p packages/auth/tsconfig.json && tsc -p packages/audit/tsconfig.json && tsc -p packages/db-abstraction/tsconfig.json && tsc -p packages/dcim-domain/tsconfig.json && tsc -p packages/domain-core/tsconfig.json && tsc -p packages/ipam-domain/tsconfig.json && tsc -p packages/network-domain/tsconfig.json && tsc -p packages/ui/tsconfig.json && tsc -p packages/shared/tsconfig.json",
     "clean": "node scripts/clean.mjs",
     "db:validate": "node scripts/validate-db-layout.mjs",
     "lint": "eslint . --ext .ts,.mjs --max-warnings=0",
@@ -19,7 +19,7 @@
     "test": "node --test tests/unit/**/*.test.mjs",
     "typecheck": "npm run clean && npm run build:packages && npm run typecheck:apps && npm run typecheck:packages",
     "typecheck:apps": "tsc -p apps/api/tsconfig.json --noEmit --pretty false && tsc -p apps/worker/tsconfig.json --noEmit --pretty false && npm --workspace @infralynx/web run typecheck",
-    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/dcim-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/ipam-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/ui/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
+    "typecheck:packages": "tsc -p packages/config/tsconfig.json --noEmit --pretty false && tsc -p packages/core-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/auth/tsconfig.json --noEmit --pretty false && tsc -p packages/audit/tsconfig.json --noEmit --pretty false && tsc -p packages/db-abstraction/tsconfig.json --noEmit --pretty false && tsc -p packages/dcim-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/domain-core/tsconfig.json --noEmit --pretty false && tsc -p packages/ipam-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/network-domain/tsconfig.json --noEmit --pretty false && tsc -p packages/ui/tsconfig.json --noEmit --pretty false && tsc -p packages/shared/tsconfig.json --noEmit --pretty false"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/packages/dcim-domain/src/index.ts
+++ b/packages/dcim-domain/src/index.ts
@@ -40,6 +40,9 @@ export interface Interface {
   readonly name: string;
   readonly kind: InterfaceKind;
   readonly enabled: boolean;
+  readonly vlanIds: readonly string[];
+  readonly ipAddressIds: readonly string[];
+  readonly cableId: string | null;
 }
 
 export interface PowerPort {
@@ -51,7 +54,7 @@ export interface PowerPort {
 
 export interface CableEndpoint {
   readonly deviceId: string;
-  readonly portId: string;
+  readonly interfaceId: string;
 }
 
 export interface Cable {
@@ -120,8 +123,11 @@ export function canOccupyRackPosition(
 }
 
 export function validateCable(cable: Cable): ValidationResult {
-  if (cable.aSide.deviceId === cable.zSide.deviceId && cable.aSide.portId === cable.zSide.portId) {
-    return { valid: false, reason: "cable endpoints must not reference the same port" };
+  if (
+    cable.aSide.deviceId === cable.zSide.deviceId &&
+    cable.aSide.interfaceId === cable.zSide.interfaceId
+  ) {
+    return { valid: false, reason: "cable endpoints must not reference the same interface" };
   }
 
   return { valid: true, reason: "cable endpoints are distinct" };

--- a/packages/ipam-domain/src/index.ts
+++ b/packages/ipam-domain/src/index.ts
@@ -12,6 +12,7 @@ export interface Vrf {
 export interface Prefix {
   readonly id: string;
   readonly vrfId: string | null;
+  readonly parentPrefixId: string | null;
   readonly cidr: string;
   readonly family: AddressFamily;
   readonly status: "active" | "reserved" | "deprecated";
@@ -28,6 +29,7 @@ export interface IpAddress {
   readonly status: "active" | "reserved" | "deprecated";
   readonly role: "loopback" | "primary" | "secondary" | "vip";
   readonly prefixId: string | null;
+  readonly interfaceId: string | null;
 }
 
 export interface Vlan {
@@ -36,6 +38,7 @@ export interface Vlan {
   readonly name: string;
   readonly status: "active" | "reserved" | "deprecated";
   readonly tenantId: string | null;
+  readonly interfaceIds: readonly string[];
 }
 
 export interface AllocationRequest {

--- a/packages/network-domain/package.json
+++ b/packages/network-domain/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@infralynx/network-domain",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/network-domain/src/index.ts
+++ b/packages/network-domain/src/index.ts
@@ -1,0 +1,78 @@
+export type InterfaceMode = "access" | "trunk" | "routed";
+
+export interface InterfaceRef {
+  readonly deviceId: string;
+  readonly interfaceId: string;
+}
+
+export interface InterfaceIpBinding {
+  readonly id: string;
+  readonly interfaceId: string;
+  readonly ipAddressId: string;
+  readonly vrfId: string | null;
+  readonly prefixId: string | null;
+  readonly role: "primary" | "secondary" | "loopback" | "vip";
+}
+
+export interface InterfaceVlanBinding {
+  readonly id: string;
+  readonly interfaceId: string;
+  readonly vlanId: string;
+  readonly mode: InterfaceMode;
+  readonly tagged: boolean;
+}
+
+export interface CableInterfaceBinding {
+  readonly id: string;
+  readonly cableId: string;
+  readonly aInterfaceId: string;
+  readonly zInterfaceId: string;
+}
+
+export interface PrefixHierarchyBinding {
+  readonly id: string;
+  readonly vrfId: string | null;
+  readonly parentPrefixId: string | null;
+  readonly prefixId: string;
+}
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly reason: string;
+}
+
+export function validateInterfaceIpBinding(binding: InterfaceIpBinding): ValidationResult {
+  if (binding.prefixId === binding.ipAddressId) {
+    return { valid: false, reason: "ip binding cannot reuse the IP address ID as a prefix ID" };
+  }
+
+  return { valid: true, reason: "interface to IP binding shape is valid" };
+}
+
+export function validateInterfaceVlanBinding(binding: InterfaceVlanBinding): ValidationResult {
+  if (binding.mode === "access" && binding.tagged) {
+    return { valid: false, reason: "access bindings must not be tagged" };
+  }
+
+  if (binding.mode === "trunk" && binding.tagged === false) {
+    return { valid: false, reason: "trunk bindings must be explicitly tagged" };
+  }
+
+  return { valid: true, reason: "interface to VLAN binding shape is valid" };
+}
+
+export function validateCableInterfaceBinding(binding: CableInterfaceBinding): ValidationResult {
+  if (binding.aInterfaceId === binding.zInterfaceId) {
+    return { valid: false, reason: "cable binding must connect two distinct interfaces" };
+  }
+
+  return { valid: true, reason: "cable to interface binding shape is valid" };
+}
+
+export function validatePrefixHierarchyBinding(binding: PrefixHierarchyBinding): ValidationResult {
+  if (binding.parentPrefixId === binding.prefixId) {
+    return { valid: false, reason: "prefix hierarchy cannot self-reference" };
+  }
+
+  return { valid: true, reason: "prefix hierarchy shape is valid" };
+}

--- a/packages/network-domain/tsconfig.json
+++ b/packages/network-domain/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -23,6 +23,8 @@ const paths = [
   "packages/domain-core/tsconfig.tsbuildinfo",
   "packages/ipam-domain/dist",
   "packages/ipam-domain/tsconfig.tsbuildinfo",
+  "packages/network-domain/dist",
+  "packages/network-domain/tsconfig.tsbuildinfo",
   "packages/ui/dist",
   "packages/ui/tsconfig.tsbuildinfo",
   "packages/shared/dist",

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -16,6 +16,12 @@ import {
   validateCable,
   validateRackPosition
 } from "../../packages/dcim-domain/dist/index.js";
+import {
+  validateCableInterfaceBinding,
+  validateInterfaceIpBinding,
+  validateInterfaceVlanBinding,
+  validatePrefixHierarchyBinding
+} from "../../packages/network-domain/dist/index.js";
 import { shellNavigation, workspacePanels } from "../../packages/ui/dist/index.js";
 import {
   canAllocateChildPrefix,
@@ -100,6 +106,7 @@ test("ipam scaffolds validate basic VRF, prefix, IP, and VLAN rules", () => {
   const prefixValidation = validatePrefix({
     id: "prefix-1",
     vrfId: "vrf-1",
+    parentPrefixId: null,
     cidr: "10.0.0.0/24",
     family: 4,
     status: "active",
@@ -114,12 +121,14 @@ test("ipam scaffolds validate basic VRF, prefix, IP, and VLAN rules", () => {
     family: 4,
     status: "active",
     role: "primary",
-    prefixId: "prefix-1"
+    prefixId: "prefix-1",
+    interfaceId: "interface-1"
   });
   const allocationDecision = canAllocateChildPrefix({
     parentPrefix: {
       id: "prefix-1",
       vrfId: "vrf-1",
+      parentPrefixId: null,
       cidr: "10.0.0.0/24",
       family: 4,
       status: "active",
@@ -132,7 +141,14 @@ test("ipam scaffolds validate basic VRF, prefix, IP, and VLAN rules", () => {
     childVrfId: "vrf-1"
   });
   const vlanDirectory = createVlanDirectory([
-    { id: "vlan-1", vlanId: 120, name: "Servers", status: "active", tenantId: "tenant-1" }
+    {
+      id: "vlan-1",
+      vlanId: 120,
+      name: "Servers",
+      status: "active",
+      tenantId: "tenant-1",
+      interfaceIds: ["interface-1"]
+    }
   ]);
 
   assert.equal(prefixValidation.valid, true);
@@ -176,8 +192,8 @@ test("dcim scaffolds validate rack occupancy and cable endpoints", () => {
   const cableValidation = validateCable({
     id: "cable-1",
     kind: "data",
-    aSide: { deviceId: "device-1", portId: "eth0" },
-    zSide: { deviceId: "device-2", portId: "eth1" },
+    aSide: { deviceId: "device-1", interfaceId: "eth0" },
+    zSide: { deviceId: "device-2", interfaceId: "eth1" },
     status: "connected"
   });
   const rackDirectory = createRackDirectory([rack]);
@@ -192,4 +208,39 @@ test("ui scaffolds expose navigation and workspace panels", () => {
   assert.equal(shellNavigation.length >= 6, true);
   assert.equal(workspacePanels.some((panel) => panel.id === "dcim"), true);
   assert.equal(shellNavigation[0]?.label, "Overview");
+});
+
+test("cross-domain bindings stay explicit and ID-based", () => {
+  const ipBinding = validateInterfaceIpBinding({
+    id: "binding-ip-1",
+    interfaceId: "interface-1",
+    ipAddressId: "ip-1",
+    vrfId: "vrf-1",
+    prefixId: "prefix-1",
+    role: "primary"
+  });
+  const vlanBinding = validateInterfaceVlanBinding({
+    id: "binding-vlan-1",
+    interfaceId: "interface-1",
+    vlanId: "vlan-1",
+    mode: "access",
+    tagged: false
+  });
+  const cableBinding = validateCableInterfaceBinding({
+    id: "binding-cable-1",
+    cableId: "cable-1",
+    aInterfaceId: "interface-1",
+    zInterfaceId: "interface-2"
+  });
+  const hierarchyBinding = validatePrefixHierarchyBinding({
+    id: "binding-prefix-1",
+    vrfId: "vrf-1",
+    parentPrefixId: "prefix-root",
+    prefixId: "prefix-child"
+  });
+
+  assert.equal(ipBinding.valid, true);
+  assert.equal(vlanBinding.valid, true);
+  assert.equal(cableBinding.valid, true);
+  assert.equal(hierarchyBinding.valid, true);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "./packages/dcim-domain" },
     { "path": "./packages/domain-core" },
     { "path": "./packages/ipam-domain" },
+    { "path": "./packages/network-domain" },
     { "path": "./packages/ui" },
     { "path": "./packages/shared" },
     { "path": "./apps/api" },


### PR DESCRIPTION
## Summary
- add the network-domain package for explicit cross-domain bindings
- extend IPAM and DCIM contracts with owned relationship IDs
- add validation helpers for interface/IP, VLAN, cable, and prefix hierarchy bindings
- identify follow-up issues for validation and integration testing\n\n## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test