### PR TITLE
Chunk 12: network modeling engine

### DIFF
--- a/packages/network-domain/src/index.ts
+++ b/packages/network-domain/src/index.ts
@@ -76,3 +76,6 @@ export function validatePrefixHierarchyBinding(binding: PrefixHierarchyBinding):
 
   return { valid: true, reason: "prefix hierarchy shape is valid" };
 }
+
+export * from "./topology/index.js";
+export * from "./path-tracing/index.js";

--- a/packages/network-domain/src/path-tracing/index.ts
+++ b/packages/network-domain/src/path-tracing/index.ts
@@ -1,0 +1,100 @@
+import { buildAdjacencyIndex, type TopologyEdge, type TopologyEdgeKind } from "../topology/index.js";
+
+export interface PathTraceStep {
+  readonly edgeId: string;
+  readonly kind: TopologyEdgeKind;
+  readonly fromId: string;
+  readonly toId: string;
+}
+
+export interface PathTraceResult {
+  readonly found: boolean;
+  readonly visitedNodeIds: readonly string[];
+  readonly path: readonly PathTraceStep[];
+  readonly reason: string;
+}
+
+export interface PathTraceRequest {
+  readonly startNodeId: string;
+  readonly targetNodeId: string;
+  readonly allowedKinds: readonly TopologyEdgeKind[];
+  readonly maxDepth: number;
+}
+
+function compareSteps(left: PathTraceStep, right: PathTraceStep) {
+  const leftKey = `${left.fromId}:${left.toId}:${left.kind}:${left.edgeId}`;
+  const rightKey = `${right.fromId}:${right.toId}:${right.kind}:${right.edgeId}`;
+
+  return leftKey.localeCompare(rightKey);
+}
+
+export function tracePath(
+  edges: readonly TopologyEdge[],
+  request: PathTraceRequest
+): PathTraceResult {
+  const adjacency = buildAdjacencyIndex(edges);
+  const queue: Array<{ nodeId: string; path: PathTraceStep[]; depth: number }> = [
+    { nodeId: request.startNodeId, path: [], depth: 0 }
+  ];
+  const visitedNodeIds = new Set<string>([request.startNodeId]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+
+    if (!current) {
+      break;
+    }
+
+    if (current.nodeId === request.targetNodeId) {
+      return {
+        found: true,
+        visitedNodeIds: [...visitedNodeIds],
+        path: current.path,
+        reason: "target node reached"
+      };
+    }
+
+    if (current.depth >= request.maxDepth) {
+      continue;
+    }
+
+    const outbound = adjacency.get(current.nodeId) ?? [];
+
+    for (const edge of [...outbound].sort((left, right) =>
+      compareSteps(
+        { edgeId: left.id, kind: left.kind, fromId: left.fromId, toId: left.toId },
+        { edgeId: right.id, kind: right.kind, fromId: right.fromId, toId: right.toId }
+      )
+    )) {
+      if (!request.allowedKinds.includes(edge.kind)) {
+        continue;
+      }
+
+      if (visitedNodeIds.has(edge.toId)) {
+        continue;
+      }
+
+      visitedNodeIds.add(edge.toId);
+      queue.push({
+        nodeId: edge.toId,
+        depth: current.depth + 1,
+        path: [
+          ...current.path,
+          {
+            edgeId: edge.id,
+            kind: edge.kind,
+            fromId: edge.fromId,
+            toId: edge.toId
+          }
+        ]
+      });
+    }
+  }
+
+  return {
+    found: false,
+    visitedNodeIds: [...visitedNodeIds],
+    path: [],
+    reason: "target node not reachable within depth and edge constraints"
+  };
+}

--- a/packages/network-domain/src/topology/index.ts
+++ b/packages/network-domain/src/topology/index.ts
@@ -1,0 +1,49 @@
+export type TopologyEdgeKind = "l2-adjacency" | "l3-adjacency" | "vlan-propagation" | "cable-link";
+
+export interface TopologyNode {
+  readonly id: string;
+  readonly domain: "dcim-interface" | "ip-address" | "prefix" | "vlan";
+}
+
+export interface TopologyEdge {
+  readonly id: string;
+  readonly kind: TopologyEdgeKind;
+  readonly fromId: string;
+  readonly toId: string;
+  readonly metadata: Record<string, string>;
+}
+
+export interface TopologyValidationResult {
+  readonly valid: boolean;
+  readonly reason: string;
+}
+
+export function validateTopologyEdge(edge: TopologyEdge): TopologyValidationResult {
+  if (edge.fromId === edge.toId) {
+    return { valid: false, reason: "topology edges must connect distinct nodes" };
+  }
+
+  if (edge.metadata["bindingId"] === edge.id) {
+    return { valid: false, reason: "topology edges must not reuse their own ID as a binding reference" };
+  }
+
+  return { valid: true, reason: "topology edge shape is valid" };
+}
+
+export function buildAdjacencyIndex(edges: readonly TopologyEdge[]) {
+  const adjacency = new Map<string, TopologyEdge[]>();
+  const orderedEdges = [...edges].sort((left, right) => {
+    const leftKey = `${left.fromId}:${left.toId}:${left.kind}:${left.id}`;
+    const rightKey = `${right.fromId}:${right.toId}:${right.kind}:${right.id}`;
+
+    return leftKey.localeCompare(rightKey);
+  });
+
+  for (const edge of orderedEdges) {
+    const current = adjacency.get(edge.fromId) ?? [];
+    current.push(edge);
+    adjacency.set(edge.fromId, current);
+  }
+
+  return adjacency;
+}

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -17,6 +17,11 @@ import {
   validateRackPosition
 } from "../../packages/dcim-domain/dist/index.js";
 import {
+  buildAdjacencyIndex,
+  tracePath,
+  validateTopologyEdge
+} from "../../packages/network-domain/dist/index.js";
+import {
   validateCableInterfaceBinding,
   validateInterfaceIpBinding,
   validateInterfaceVlanBinding,
@@ -243,4 +248,50 @@ test("cross-domain bindings stay explicit and ID-based", () => {
   assert.equal(vlanBinding.valid, true);
   assert.equal(cableBinding.valid, true);
   assert.equal(hierarchyBinding.valid, true);
+});
+
+test("network topology and path tracing stay deterministic", () => {
+  const l2Edge = validateTopologyEdge({
+    id: "edge-l2-1",
+    kind: "l2-adjacency",
+    fromId: "interface-1",
+    toId: "interface-2",
+    metadata: { cableId: "cable-1" }
+  });
+  const edges = [
+    {
+      id: "edge-l2-1",
+      kind: "l2-adjacency",
+      fromId: "interface-1",
+      toId: "interface-2",
+      metadata: { cableId: "cable-1" }
+    },
+    {
+      id: "edge-vlan-1",
+      kind: "vlan-propagation",
+      fromId: "interface-2",
+      toId: "vlan-1",
+      metadata: { mode: "access" }
+    },
+    {
+      id: "edge-l3-1",
+      kind: "l3-adjacency",
+      fromId: "interface-2",
+      toId: "ip-1",
+      metadata: { bindingId: "binding-ip-1" }
+    }
+  ];
+  const adjacency = buildAdjacencyIndex(edges);
+  const path = tracePath(edges, {
+    startNodeId: "interface-1",
+    targetNodeId: "ip-1",
+    allowedKinds: ["l2-adjacency", "l3-adjacency"],
+    maxDepth: 4
+  });
+
+  assert.equal(l2Edge.valid, true);
+  assert.equal(adjacency.get("interface-1")?.length, 1);
+  assert.equal(path.found, true);
+  assert.equal(path.path.length, 2);
+  assert.equal(path.path[1]?.kind, "l3-adjacency");
 });


### PR DESCRIPTION
## Summary
- add deterministic topology edge scaffolds to @infralynx/network-domain
- add breadth-first path tracing helpers and unit coverage
- record follow-up issues for scenario coverage and performance validation

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test