### PR TITLE
Chunk 13: add UI data integration layer

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,8 +1,348 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
+
 import { workspaceMetadata } from "../../../packages/config/dist/index.js";
+import {
+  defaultCorePermissions,
+  defaultCoreRoles,
+  defaultTenantStatuses,
+  type Tenant
+} from "../../../packages/core-domain/dist/index.js";
+import { type Rack, type Site, validateCable, validateRackPosition } from "../../../packages/dcim-domain/dist/index.js";
 import { platformBoundaries } from "../../../packages/domain-core/dist/index.js";
+import { type IpAddress, type Prefix, type Vlan, validateIpAddress, validatePrefix } from "../../../packages/ipam-domain/dist/index.js";
+import {
+  tracePath,
+  validateInterfaceIpBinding,
+  validateInterfaceVlanBinding,
+  validateTopologyEdge
+} from "../../../packages/network-domain/dist/index.js";
+
+export interface ApiMetricResponse {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ApiDomainResponse {
+  readonly id: string;
+  readonly title: string;
+  readonly status: "ready" | "attention" | "planned";
+  readonly summary: string;
+  readonly metrics: readonly ApiMetricResponse[];
+  readonly indicators: readonly string[];
+}
+
+export interface ApiOverviewResponse {
+  readonly generatedAt: string;
+  readonly workspace: {
+    readonly name: string;
+    readonly runtime: string;
+    readonly boundary: string;
+  };
+  readonly domains: readonly ApiDomainResponse[];
+  readonly notices: readonly string[];
+}
+
+const referenceTenants: readonly Tenant[] = [
+  { id: "tenant-ops", slug: "operations", name: "Operations", status: "active" },
+  { id: "tenant-net", slug: "network-engineering", name: "Network Engineering", status: "active" }
+] as const;
+
+const referencePrefixes: readonly Prefix[] = [
+  {
+    id: "prefix-root",
+    vrfId: "vrf-global",
+    parentPrefixId: null,
+    cidr: "10.40.0.0/16",
+    family: 4,
+    status: "active",
+    allocationMode: "hierarchical",
+    tenantId: "tenant-net",
+    vlanId: null
+  },
+  {
+    id: "prefix-leaf",
+    vrfId: "vrf-global",
+    parentPrefixId: "prefix-root",
+    cidr: "10.40.12.0/24",
+    family: 4,
+    status: "active",
+    allocationMode: "pool",
+    tenantId: "tenant-net",
+    vlanId: "vlan-120"
+  }
+] as const;
+
+const referenceAddresses: readonly IpAddress[] = [
+  {
+    id: "ip-leaf-sw1",
+    vrfId: "vrf-global",
+    address: "10.40.12.10/24",
+    family: 4,
+    status: "active",
+    role: "primary",
+    prefixId: "prefix-leaf",
+    interfaceId: "interface-leaf-sw1"
+  },
+  {
+    id: "ip-leaf-sw2",
+    vrfId: "vrf-global",
+    address: "10.40.12.11/24",
+    family: 4,
+    status: "active",
+    role: "primary",
+    prefixId: "prefix-leaf",
+    interfaceId: "interface-leaf-sw2"
+  }
+] as const;
+
+const referenceVlans: readonly Vlan[] = [
+  {
+    id: "vlan-120",
+    vlanId: 120,
+    name: "Production Leaf",
+    status: "active",
+    tenantId: "tenant-net",
+    interfaceIds: ["interface-leaf-sw1", "interface-leaf-sw2"]
+  }
+] as const;
+
+const referenceSites: readonly Site[] = [
+  { id: "site-dal1", slug: "dal1", name: "Dallas One", tenantId: "tenant-ops" }
+] as const;
+
+const referenceRacks: readonly Rack[] = [
+  { id: "rack-a1", siteId: "site-dal1", name: "A1", totalUnits: 42 },
+  { id: "rack-a2", siteId: "site-dal1", name: "A2", totalUnits: 42 }
+] as const;
+
+function createDomainResponse(): ApiOverviewResponse {
+  const validPrefixes = referencePrefixes.filter((prefix) => validatePrefix(prefix).valid).length;
+  const validAddresses = referenceAddresses.filter((address) => validateIpAddress(address).valid).length;
+  const rackPlacement = validateRackPosition(referenceRacks[0], {
+    rackId: "rack-a1",
+    face: "front",
+    startingUnit: 18,
+    heightUnits: 2
+  });
+  const cableValidation = validateCable({
+    id: "cable-leaf-1",
+    kind: "data",
+    aSide: { deviceId: "device-leaf-sw1", interfaceId: "xe-0/0/1" },
+    zSide: { deviceId: "device-leaf-sw2", interfaceId: "xe-0/0/1" },
+    status: "connected"
+  });
+  const topologyValidation = validateTopologyEdge({
+    id: "edge-l2-leaf",
+    kind: "l2-adjacency",
+    fromId: "interface-leaf-sw1",
+    toId: "interface-leaf-sw2",
+    metadata: { cableId: "cable-leaf-1" }
+  });
+  const interfaceBinding = validateInterfaceIpBinding({
+    id: "binding-ip-leaf",
+    interfaceId: "interface-leaf-sw1",
+    ipAddressId: "ip-leaf-sw1",
+    vrfId: "vrf-global",
+    prefixId: "prefix-leaf",
+    role: "primary"
+  });
+  const vlanBinding = validateInterfaceVlanBinding({
+    id: "binding-vlan-leaf",
+    interfaceId: "interface-leaf-sw1",
+    vlanId: "vlan-120",
+    mode: "access",
+    tagged: false
+  });
+  const trace = tracePath(
+    [
+      {
+        id: "edge-l2-leaf",
+        kind: "l2-adjacency",
+        fromId: "interface-leaf-sw1",
+        toId: "interface-leaf-sw2",
+        metadata: { cableId: "cable-leaf-1" }
+      },
+      {
+        id: "edge-l3-leaf",
+        kind: "l3-adjacency",
+        fromId: "interface-leaf-sw2",
+        toId: "ip-leaf-sw2",
+        metadata: { bindingId: "binding-ip-leaf-sw2" }
+      }
+    ],
+    {
+      startNodeId: "interface-leaf-sw1",
+      targetNodeId: "ip-leaf-sw2",
+      allowedKinds: ["l2-adjacency", "l3-adjacency"],
+      maxDepth: 3
+    }
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    workspace: {
+      name: workspaceMetadata.name,
+      runtime: workspaceMetadata.runtime,
+      boundary: platformBoundaries.api
+    },
+    domains: [
+      {
+        id: "overview",
+        title: "Platform Overview",
+        status: "ready",
+        summary: "UI integration now consumes backend domain summaries through a stable API layer.",
+        metrics: [
+          { label: "Active domains", value: "6" },
+          { label: "Reference tenants", value: String(referenceTenants.length) },
+          { label: "Stable trace path", value: trace.found ? `${trace.path.length} hops` : "unresolved" }
+        ],
+        indicators: [
+          "API payloads are normalized before rendering",
+          "Loading and retry states are explicit",
+          "UI shell no longer depends on static panel copy"
+        ]
+      },
+      {
+        id: "core",
+        title: "Core Platform",
+        status: "ready",
+        summary: "Identity and policy data are exposed as a compact control-plane summary for UI consumption.",
+        metrics: [
+          { label: "Roles", value: String(defaultCoreRoles.length) },
+          { label: "Permissions", value: String(defaultCorePermissions.length) },
+          { label: "Tenant statuses", value: String(defaultTenantStatuses.length) }
+        ],
+        indicators: [
+          "Tenancy summary available",
+          "Permission catalog exposed by API",
+          "Audit-ready control-plane framing retained"
+        ]
+      },
+      {
+        id: "ipam",
+        title: "IPAM",
+        status: validPrefixes === referencePrefixes.length && validAddresses === referenceAddresses.length ? "ready" : "attention",
+        summary: "Addressing data is delivered as normalized VRF, prefix, address, and VLAN counts with validation context.",
+        metrics: [
+          { label: "Prefixes", value: String(referencePrefixes.length) },
+          { label: "Addresses", value: String(referenceAddresses.length) },
+          { label: "VLANs", value: String(referenceVlans.length) }
+        ],
+        indicators: [
+          `${validPrefixes}/${referencePrefixes.length} reference prefixes validate`,
+          `${validAddresses}/${referenceAddresses.length} reference addresses validate`,
+          vlanBinding.reason
+        ]
+      },
+      {
+        id: "dcim",
+        title: "DCIM",
+        status: rackPlacement.valid && cableValidation.valid ? "ready" : "attention",
+        summary: "Physical inventory data is exposed through site, rack, and cable summaries that preserve explicit relationships.",
+        metrics: [
+          { label: "Sites", value: String(referenceSites.length) },
+          { label: "Racks", value: String(referenceRacks.length) },
+          { label: "Cable checks", value: cableValidation.valid ? "passing" : "blocked" }
+        ],
+        indicators: [
+          rackPlacement.reason,
+          cableValidation.reason,
+          "Rack and cable relationships remain explicit"
+        ]
+      },
+      {
+        id: "automation",
+        title: "Automation",
+        status: "planned",
+        summary: "Jobs, imports, exports, and webhook automation remain queued for a later domain implementation chunk.",
+        metrics: [
+          { label: "Queued jobs", value: "0" },
+          { label: "Webhook contracts", value: "planned" },
+          { label: "Import pipelines", value: "planned" }
+        ],
+        indicators: [
+          "UI uses a stable placeholder contract",
+          "No domain implementation leak into the shell",
+          "Ready for future mutation workflows"
+        ]
+      },
+      {
+        id: "operations",
+        title: "Operations",
+        status: interfaceBinding.valid && topologyValidation.valid ? "ready" : "attention",
+        summary: "Operational visibility shows API boundary health, UI contract stability, and topology integration readiness.",
+        metrics: [
+          { label: "API boundary", value: "stable" },
+          { label: "Path tracing", value: trace.reason },
+          { label: "Topology edges", value: topologyValidation.valid ? "valid" : "invalid" }
+        ],
+        indicators: [
+          interfaceBinding.reason,
+          topologyValidation.reason,
+          "Retry-safe fetch behavior is active in the shell"
+        ]
+      }
+    ],
+    notices: [
+      "Backend payloads are normalized in the web layer before rendering.",
+      "Error handling keeps transport failures separate from empty-domain states.",
+      "Domain IDs remain explicit to avoid schema coupling in the shell."
+    ]
+  };
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown) {
+  response.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    "Access-Control-Allow-Origin": "*"
+  });
+  response.end(JSON.stringify(payload));
+}
+
+export function handleApiRequest(request: IncomingMessage, response: ServerResponse) {
+  const requestUrl = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+
+  if (request.method === "OPTIONS") {
+    response.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type"
+    });
+    response.end();
+
+    return;
+  }
+
+  if (request.method === "GET" && requestUrl.pathname === "/api/overview") {
+    sendJson(response, 200, createDomainResponse());
+
+    return;
+  }
+
+  sendJson(response, 404, {
+    error: {
+      code: "not_found",
+      message: `No API route matched ${request.method ?? "GET"} ${requestUrl.pathname}`
+    }
+  });
+}
 
 export function describeApiSurface(): string {
   return `${workspaceMetadata.name} API boundary: ${platformBoundaries.api}`;
 }
 
-console.log(describeApiSurface());
+export function startApiServer(port = Number(process.env["INFRALYNX_API_PORT"] ?? "4010")) {
+  const server = createServer(handleApiRequest);
+
+  server.listen(port, () => {
+    console.log(`${describeApiSurface()} on http://localhost:${port}/api/overview`);
+  });
+
+  return server;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startApiServer();
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,7 +1,7 @@
 import { startTransition, useDeferredValue, useEffect, useMemo, useState } from "react";
 
-import { workspaceMetadata } from "../../../packages/config/dist/index.js";
-import { shellNavigation, workspacePanels, getNavigationItem } from "../../../packages/ui/dist/index.js";
+import { shellNavigation, getNavigationItem, workspacePanels } from "../../../packages/ui/dist/index.js";
+import { useDomainOverview } from "./hooks/use-domain-overview.js";
 
 function getSectionFromHash(): string {
   const hash = window.location.hash.replace(/^#/, "");
@@ -9,9 +9,23 @@ function getSectionFromHash(): string {
   return shellNavigation.some((item) => item.id === hash) ? hash : "overview";
 }
 
+function formatSyncTime(timestamp: string | null): string {
+  if (!timestamp) {
+    return "Waiting for API";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(timestamp));
+}
+
 export function App() {
   const [activeSection, setActiveSection] = useState(() => getSectionFromHash());
   const deferredSection = useDeferredValue(activeSection);
+  const { status, data, errorMessage, retry } = useDomainOverview();
 
   useEffect(() => {
     const onHashChange = () => {
@@ -26,11 +40,31 @@ export function App() {
   }, []);
 
   const activeItem = useMemo(() => getNavigationItem(deferredSection), [deferredSection]);
-
   const navigation = shellNavigation.map((item) => ({
     ...item,
     active: item.id === activeSection
   }));
+  const activeDomain = useMemo(
+    () => data?.domains.find((domain) => domain.id === deferredSection) ?? data?.domains[0] ?? null,
+    [data, deferredSection]
+  );
+  const domainPanels = useMemo(
+    () => data?.domains.filter((domain) => domain.id !== "overview") ?? [],
+    [data]
+  );
+  const fallbackPanels = workspacePanels.map((panel) => ({
+    id: panel.id,
+    title: panel.title,
+    statusLabel: "Static",
+    tone: "planned" as const,
+    summary: panel.summary,
+    metrics: panel.indicators.slice(0, 3).map((indicator, index) => ({
+      label: `Signal ${index + 1}`,
+      value: indicator
+    })),
+    indicators: panel.indicators
+  }));
+  const visiblePanels = domainPanels.length > 0 ? domainPanels : fallbackPanels;
 
   return (
     <div className="shell">
@@ -59,39 +93,79 @@ export function App() {
 
         <div className="shell__rail-footer">
           <p>Workspace state</p>
-          <strong>Structured for multi-domain delivery</strong>
+          <strong>{status === "ready" ? "Live domain summary connected" : "Waiting for backend data"}</strong>
         </div>
       </aside>
 
       <main className="shell__workspace">
         <header className="shell__header">
           <div>
-            <p className="shell__eyebrow">UI shell baseline</p>
-            <h1>{workspaceMetadata.name}</h1>
+            <p className="shell__eyebrow">UI data integration layer</p>
+            <h1>{data?.workspaceName ?? "InfraLynx Platform"}</h1>
           </div>
 
           <div className="shell__header-meta">
-            <span>Active section</span>
-            <strong>{activeItem.label}</strong>
+            <span>Last synced</span>
+            <strong>{formatSyncTime(data?.syncedAt ?? null)}</strong>
           </div>
         </header>
 
         <section className="shell__hero" id={activeItem.id}>
           <div className="shell__hero-copy">
-            <p className="shell__eyebrow">Operational shell</p>
-            <h2>One workspace for physical, logical, and policy infrastructure.</h2>
+            <p className="shell__eyebrow">{status === "ready" ? activeItem.label : "Data status"}</p>
+            <h2>
+              {status === "loading" && "Synchronizing backend domain summaries."}
+              {status === "error" && "Domain data is temporarily unavailable."}
+              {status === "ready" && activeDomain?.title}
+              {status === "idle" && "Preparing the InfraLynx workspace."}
+            </h2>
             <p>
-              The first UI layer separates domains clearly, keeps navigation persistent, and leaves
-              room for deep operational surfaces without collapsing into dashboard-card clutter.
+              {status === "ready" && activeDomain?.summary}
+              {status === "loading" &&
+                "The shell is requesting normalized domain payloads from the InfraLynx API and preparing workspace-ready view models."}
+              {status === "error" && errorMessage}
+              {status === "idle" &&
+                "The UI keeps navigation stable while the first domain snapshot is assembled."}
             </p>
+
+            {status === "error" ? (
+              <div className="shell__callout shell__callout--error">
+                <strong>Fetch failed</strong>
+                <span>{errorMessage}</span>
+                <button type="button" className="shell__button" onClick={retry}>
+                  Retry fetch
+                </button>
+              </div>
+            ) : null}
+
+            {status === "loading" ? (
+              <div className="shell__callout">
+                <strong>Loading domain snapshot</strong>
+                <span>Transport, normalization, and state reduction are all in progress.</span>
+                <div className="shell__loading-bar" aria-hidden="true" />
+              </div>
+            ) : null}
           </div>
 
           <div className="shell__hero-grid" aria-label="Domain overview">
-            {workspacePanels.map((panel) => (
-              <article key={panel.id} className="shell__panel">
-                <p className="shell__panel-eyebrow">{panel.eyebrow}</p>
+            {visiblePanels.map((panel) => (
+              <article key={panel.id} className={`shell__panel shell__panel--${panel.tone}`}>
+                <div className="shell__panel-header">
+                  <p className="shell__panel-eyebrow">{panel.statusLabel}</p>
+                  <span className={`shell__status-badge shell__status-badge--${panel.tone}`}>
+                    {panel.statusLabel}
+                  </span>
+                </div>
                 <h3>{panel.title}</h3>
                 <p>{panel.summary}</p>
+                <div className="shell__metric-grid">
+                  {panel.metrics.map((metric) => (
+                    <div key={`${panel.id}-${metric.label}`} className="shell__metric">
+                      <span>{metric.label}</span>
+                      <strong>{metric.value}</strong>
+                    </div>
+                  ))}
+                </div>
                 <ul>
                   {panel.indicators.map((indicator) => (
                     <li key={indicator}>{indicator}</li>
@@ -104,16 +178,16 @@ export function App() {
 
         <section className="shell__strip">
           <div>
-            <span>Navigation model</span>
-            <strong>Persistent left rail with domain-first wayfinding</strong>
+            <span>Data contract</span>
+            <strong>{data?.boundary ?? "Normalized UI contract pending"}</strong>
           </div>
           <div>
-            <span>Surface model</span>
-            <strong>Primary workspace plus contextual right rail</strong>
+            <span>Runtime</span>
+            <strong>{data?.runtime ?? "Awaiting backend metadata"}</strong>
           </div>
           <div>
-            <span>Design baseline</span>
-            <strong>Dark-first shell with restrained accent signaling</strong>
+            <span>Transport state</span>
+            <strong>{status === "ready" ? "Healthy fetch cycle" : status === "error" ? "Retry required" : "Loading"}</strong>
           </div>
         </section>
       </main>
@@ -121,20 +195,24 @@ export function App() {
       <aside className="shell__context">
         <section className="shell__context-block">
           <p className="shell__eyebrow">Current focus</p>
-          <h3>{activeItem.label}</h3>
+          <h3>{activeDomain?.title ?? activeItem.label}</h3>
           <p>
-            Navigation changes are hash-driven so the shell works immediately without backend
-            routing. Domain apps can replace the central workspace later without reworking the outer
-            frame.
+            {status === "ready"
+              ? activeDomain?.summary
+              : "The context rail remains stable while service, hook, and state layers converge on a normalized UI payload."}
           </p>
         </section>
 
         <section className="shell__context-block">
-          <p className="shell__eyebrow">Shell decisions</p>
+          <p className="shell__eyebrow">Integration notes</p>
           <ul className="shell__notes">
-            <li>Navigation remains domain-led instead of feature-led.</li>
-            <li>Context rail is reserved for status, selection, and workflow cues.</li>
-            <li>Shared UI tokens live in `@infralynx/ui` to prevent app-only drift.</li>
+            {(data?.notices ?? [
+              "API requests are isolated in src/services.",
+              "State transitions are isolated in src/state.",
+              "React hooks own loading and retry orchestration."
+            ]).map((notice) => (
+              <li key={notice}>{notice}</li>
+            ))}
           </ul>
         </section>
       </aside>

--- a/apps/web/src/hooks/use-domain-overview.ts
+++ b/apps/web/src/hooks/use-domain-overview.ts
@@ -1,0 +1,52 @@
+import { useEffect, useReducer, useState } from "react";
+
+import {
+  fetchDomainOverview,
+  toErrorMessage,
+  type UiOverviewModel
+} from "../services/domain-overview.js";
+import {
+  createInitialDomainOverviewState,
+  domainOverviewReducer
+} from "../state/domain-overview-state.js";
+
+export interface UseDomainOverviewResult {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiOverviewModel | null;
+  readonly errorMessage: string | null;
+  readonly retry: () => void;
+}
+
+export function useDomainOverview(): UseDomainOverviewResult {
+  const [state, dispatch] = useReducer(
+    domainOverviewReducer,
+    undefined,
+    createInitialDomainOverviewState
+  );
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    dispatch({ type: "load_started" });
+
+    fetchDomainOverview(controller.signal)
+      .then((payload) => {
+        dispatch({ type: "load_succeeded", payload });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        dispatch({ type: "load_failed", message: toErrorMessage(error) });
+      });
+
+    return () => controller.abort();
+  }, [attempt]);
+
+  return {
+    ...state,
+    retry: () => setAttempt((currentAttempt) => currentAttempt + 1)
+  };
+}

--- a/apps/web/src/services/api-client.ts
+++ b/apps/web/src/services/api-client.ts
@@ -1,0 +1,35 @@
+export class ApiClientError extends Error {
+  readonly statusCode: number | null;
+  readonly retryable: boolean;
+
+  constructor(message: string, statusCode: number | null, retryable: boolean) {
+    super(message);
+    this.name = "ApiClientError";
+    this.statusCode = statusCode;
+    this.retryable = retryable;
+  }
+}
+
+export async function fetchJson<T>(path: string, signal?: AbortSignal): Promise<T> {
+  let response: Response;
+
+  try {
+    response = await fetch(path, { signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
+
+    throw new ApiClientError("Unable to reach the InfraLynx API.", null, true);
+  }
+
+  if (!response.ok) {
+    throw new ApiClientError(
+      `InfraLynx API request failed with status ${response.status}.`,
+      response.status,
+      response.status >= 500
+    );
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/apps/web/src/services/domain-overview.ts
+++ b/apps/web/src/services/domain-overview.ts
@@ -1,0 +1,102 @@
+import { fetchJson, ApiClientError } from "./api-client.js";
+
+export interface ApiMetricResponse {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ApiDomainResponse {
+  readonly id: string;
+  readonly title: string;
+  readonly status: "ready" | "attention" | "planned";
+  readonly summary: string;
+  readonly metrics: readonly ApiMetricResponse[];
+  readonly indicators: readonly string[];
+}
+
+export interface ApiOverviewResponse {
+  readonly generatedAt: string;
+  readonly workspace: {
+    readonly name: string;
+    readonly runtime: string;
+    readonly boundary: string;
+  };
+  readonly domains: readonly ApiDomainResponse[];
+  readonly notices: readonly string[];
+}
+
+export interface UiMetric {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface UiDomainSnapshot {
+  readonly id: string;
+  readonly title: string;
+  readonly tone: "live" | "warning" | "planned";
+  readonly statusLabel: string;
+  readonly summary: string;
+  readonly metrics: readonly UiMetric[];
+  readonly indicators: readonly string[];
+}
+
+export interface UiOverviewModel {
+  readonly syncedAt: string;
+  readonly workspaceName: string;
+  readonly runtime: string;
+  readonly boundary: string;
+  readonly domains: readonly UiDomainSnapshot[];
+  readonly notices: readonly string[];
+}
+
+function toDomainTone(status: ApiDomainResponse["status"]): UiDomainSnapshot["tone"] {
+  if (status === "attention") {
+    return "warning";
+  }
+
+  return status === "planned" ? "planned" : "live";
+}
+
+function toStatusLabel(status: ApiDomainResponse["status"]): string {
+  if (status === "attention") {
+    return "Needs attention";
+  }
+
+  return status === "planned" ? "Planned" : "Live";
+}
+
+export function normalizeOverviewResponse(payload: ApiOverviewResponse): UiOverviewModel {
+  return {
+    syncedAt: payload.generatedAt,
+    workspaceName: payload.workspace.name,
+    runtime: payload.workspace.runtime,
+    boundary: payload.workspace.boundary,
+    domains: payload.domains.map((domain) => ({
+      id: domain.id,
+      title: domain.title,
+      tone: toDomainTone(domain.status),
+      statusLabel: toStatusLabel(domain.status),
+      summary: domain.summary,
+      metrics: domain.metrics.slice(0, 3).map((metric) => ({
+        label: metric.label,
+        value: metric.value
+      })),
+      indicators: domain.indicators.slice(0, 3)
+    })),
+    notices: payload.notices.slice(0, 3)
+  };
+}
+
+export async function fetchDomainOverview(signal?: AbortSignal): Promise<UiOverviewModel> {
+  const payload = await fetchJson<ApiOverviewResponse>("/api/overview", signal);
+
+  return normalizeOverviewResponse(payload);
+}
+
+export function toErrorMessage(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.message;
+  }
+
+  return "InfraLynx was unable to normalize the latest domain payload.";
+}

--- a/apps/web/src/shell.css
+++ b/apps/web/src/shell.css
@@ -255,9 +255,144 @@ a {
   padding-left: 18px;
 }
 
+.shell__panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.shell__panel--live {
+  border-color: rgba(109, 166, 215, 0.45);
+}
+
+.shell__panel--warning {
+  border-color: rgba(215, 178, 109, 0.65);
+}
+
+.shell__panel--planned {
+  border-color: rgba(139, 214, 167, 0.35);
+}
+
+.shell__status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(85, 111, 138, 0.55);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.shell__status-badge--live {
+  color: var(--ui-accent-cool);
+  border-color: rgba(109, 166, 215, 0.5);
+}
+
+.shell__status-badge--warning {
+  color: var(--ui-accent);
+  border-color: rgba(215, 178, 109, 0.55);
+}
+
+.shell__status-badge--planned {
+  color: var(--ui-accent-signal);
+  border-color: rgba(139, 214, 167, 0.4);
+}
+
+.shell__metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.shell__metric {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(12, 19, 29, 0.32);
+  border: 1px solid rgba(57, 80, 106, 0.35);
+}
+
+.shell__metric span {
+  display: block;
+  color: var(--ui-text-muted);
+  font-size: 0.76rem;
+  margin-bottom: 6px;
+}
+
+.shell__metric strong {
+  display: block;
+  color: var(--ui-text);
+  font-size: 0.96rem;
+}
+
 .shell__panel li,
 .shell__notes li {
   margin-bottom: 8px;
+}
+
+.shell__callout {
+  margin-top: 22px;
+  padding: 16px 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(57, 80, 106, 0.55);
+  background: rgba(12, 19, 29, 0.46);
+}
+
+.shell__callout strong,
+.shell__callout span {
+  display: block;
+}
+
+.shell__callout strong {
+  margin-bottom: 6px;
+}
+
+.shell__callout span {
+  color: var(--ui-text-muted);
+  line-height: 1.5;
+}
+
+.shell__callout--error {
+  border-color: rgba(215, 178, 109, 0.55);
+}
+
+.shell__button {
+  margin-top: 14px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(109, 166, 215, 0.55);
+  background: rgba(109, 166, 215, 0.14);
+  color: var(--ui-text);
+  cursor: pointer;
+  font: inherit;
+}
+
+.shell__button:hover {
+  border-color: rgba(215, 178, 109, 0.65);
+  background: rgba(215, 178, 109, 0.16);
+}
+
+.shell__loading-bar {
+  margin-top: 14px;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(57, 80, 106, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.shell__loading-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 38%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--ui-accent-cool), var(--ui-accent));
+  animation: shell-load 1.2s ease-in-out infinite;
 }
 
 .shell__strip {
@@ -303,6 +438,16 @@ a {
   }
 }
 
+@keyframes shell-load {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(280%);
+  }
+}
+
 @media (max-width: 1100px) {
   .shell {
     grid-template-columns: 240px minmax(0, 1fr);
@@ -316,6 +461,10 @@ a {
   }
 
   .shell__hero {
+    grid-template-columns: 1fr;
+  }
+
+  .shell__metric-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/state/domain-overview-state.ts
+++ b/apps/web/src/state/domain-overview-state.ts
@@ -1,0 +1,48 @@
+import type { UiOverviewModel } from "../services/domain-overview.js";
+
+export interface DomainOverviewState {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiOverviewModel | null;
+  readonly errorMessage: string | null;
+}
+
+export type DomainOverviewAction =
+  | { readonly type: "load_started" }
+  | { readonly type: "load_succeeded"; readonly payload: UiOverviewModel }
+  | { readonly type: "load_failed"; readonly message: string };
+
+export function createInitialDomainOverviewState(): DomainOverviewState {
+  return {
+    status: "idle",
+    data: null,
+    errorMessage: null
+  };
+}
+
+export function domainOverviewReducer(
+  state: DomainOverviewState,
+  action: DomainOverviewAction
+): DomainOverviewState {
+  switch (action.type) {
+    case "load_started":
+      return {
+        ...state,
+        status: "loading",
+        errorMessage: null
+      };
+    case "load_succeeded":
+      return {
+        status: "ready",
+        data: action.payload,
+        errorMessage: null
+      };
+    case "load_failed":
+      return {
+        ...state,
+        status: "error",
+        errorMessage: action.message
+      };
+    default:
+      return state;
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,5 +2,13 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: process.env["INFRALYNX_WEB_API_ORIGIN"] ?? "http://localhost:4010",
+        changeOrigin: true
+      }
+    }
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.24.0",
+        "@types/node": "^24.12.0",
         "eslint": "^9.24.0",
         "globals": "^16.0.0",
         "typescript": "^5.8.3",
@@ -1568,6 +1569,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -3166,6 +3177,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
+    "@types/node": "^24.12.0",
     "eslint": "^9.24.0",
     "globals": "^16.0.0",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## Summary
- add a minimal API endpoint for overview domain data
- add web service, hook, and state layers for normalization and fetch orchestration
- render loading, error, retry, and ready states in the shell

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test
- runtime smoke test for /api/overview