### PR TITLE
Chunk 14: add rack elevation visualization

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,48 @@ export interface ApiOverviewResponse {
   readonly notices: readonly string[];
 }
 
+export interface ApiRackPortResponse {
+  readonly id: string;
+  readonly label: string;
+  readonly side: "left" | "right";
+  readonly status: "connected" | "available" | "disabled";
+  readonly cableId: string | null;
+  readonly peerPortLabel: string | null;
+}
+
+export interface ApiRackDeviceResponse {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly tone: "network" | "compute" | "power" | "storage";
+  readonly startUnit: number;
+  readonly heightUnits: number;
+  readonly ports: readonly ApiRackPortResponse[];
+}
+
+export interface ApiRackCableResponse {
+  readonly id: string;
+  readonly fromDeviceId: string;
+  readonly fromPortId: string;
+  readonly fromPortLabel: string;
+  readonly toDeviceId: string;
+  readonly toPortId: string;
+  readonly toPortLabel: string;
+}
+
+export interface ApiRackResponse {
+  readonly generatedAt: string;
+  readonly rack: {
+    readonly id: string;
+    readonly name: string;
+    readonly siteName: string;
+    readonly totalUnits: number;
+    readonly devices: readonly ApiRackDeviceResponse[];
+    readonly cables: readonly ApiRackCableResponse[];
+  };
+  readonly guidance: readonly string[];
+}
+
 const referenceTenants: readonly Tenant[] = [
   { id: "tenant-ops", slug: "operations", name: "Operations", status: "active" },
   { id: "tenant-net", slug: "network-engineering", name: "Network Engineering", status: "active" }
@@ -115,6 +157,201 @@ const referenceRacks: readonly Rack[] = [
   { id: "rack-a1", siteId: "site-dal1", name: "A1", totalUnits: 42 },
   { id: "rack-a2", siteId: "site-dal1", name: "A2", totalUnits: 42 }
 ] as const;
+
+function createRackResponse(): ApiRackResponse {
+  return {
+    generatedAt: new Date().toISOString(),
+    rack: {
+      id: "rack-a1",
+      name: "A1",
+      siteName: "Dallas One",
+      totalUnits: 42,
+      devices: [
+        {
+          id: "device-leaf-sw1",
+          name: "leaf-sw1",
+          role: "Top-of-rack switch",
+          tone: "network",
+          startUnit: 40,
+          heightUnits: 2,
+          ports: [
+            {
+              id: "port-leaf-sw1-1",
+              label: "xe-0/0/1",
+              side: "left",
+              status: "connected",
+              cableId: "cable-leaf-a",
+              peerPortLabel: "xe-0/0/1"
+            },
+            {
+              id: "port-leaf-sw1-2",
+              label: "xe-0/0/2",
+              side: "right",
+              status: "connected",
+              cableId: "cable-host-a",
+              peerPortLabel: "eth0"
+            },
+            {
+              id: "port-leaf-sw1-mgmt",
+              label: "mgmt0",
+              side: "left",
+              status: "available",
+              cableId: null,
+              peerPortLabel: null
+            }
+          ]
+        },
+        {
+          id: "device-leaf-sw2",
+          name: "leaf-sw2",
+          role: "Top-of-rack switch",
+          tone: "network",
+          startUnit: 38,
+          heightUnits: 2,
+          ports: [
+            {
+              id: "port-leaf-sw2-1",
+              label: "xe-0/0/1",
+              side: "left",
+              status: "connected",
+              cableId: "cable-leaf-a",
+              peerPortLabel: "xe-0/0/1"
+            },
+            {
+              id: "port-leaf-sw2-2",
+              label: "xe-0/0/2",
+              side: "right",
+              status: "connected",
+              cableId: "cable-host-b",
+              peerPortLabel: "eth0"
+            },
+            {
+              id: "port-leaf-sw2-mgmt",
+              label: "mgmt0",
+              side: "left",
+              status: "available",
+              cableId: null,
+              peerPortLabel: null
+            }
+          ]
+        },
+        {
+          id: "device-server-01",
+          name: "compute-01",
+          role: "Application host",
+          tone: "compute",
+          startUnit: 30,
+          heightUnits: 2,
+          ports: [
+            {
+              id: "port-server-01-eth0",
+              label: "eth0",
+              side: "left",
+              status: "connected",
+              cableId: "cable-host-a",
+              peerPortLabel: "xe-0/0/2"
+            },
+            {
+              id: "port-server-01-eth1",
+              label: "eth1",
+              side: "right",
+              status: "available",
+              cableId: null,
+              peerPortLabel: null
+            }
+          ]
+        },
+        {
+          id: "device-server-02",
+          name: "compute-02",
+          role: "Application host",
+          tone: "compute",
+          startUnit: 26,
+          heightUnits: 2,
+          ports: [
+            {
+              id: "port-server-02-eth0",
+              label: "eth0",
+              side: "left",
+              status: "connected",
+              cableId: "cable-host-b",
+              peerPortLabel: "xe-0/0/2"
+            },
+            {
+              id: "port-server-02-eth1",
+              label: "eth1",
+              side: "right",
+              status: "disabled",
+              cableId: null,
+              peerPortLabel: null
+            }
+          ]
+        },
+        {
+          id: "device-pdu-a",
+          name: "pdu-a",
+          role: "Power distribution",
+          tone: "power",
+          startUnit: 10,
+          heightUnits: 4,
+          ports: [
+            {
+              id: "port-pdu-a-feed1",
+              label: "feed-a",
+              side: "left",
+              status: "connected",
+              cableId: "cable-power-a",
+              peerPortLabel: "psu-a"
+            }
+          ]
+        }
+      ],
+      cables: [
+        {
+          id: "cable-leaf-a",
+          fromDeviceId: "device-leaf-sw1",
+          fromPortId: "port-leaf-sw1-1",
+          fromPortLabel: "xe-0/0/1",
+          toDeviceId: "device-leaf-sw2",
+          toPortId: "port-leaf-sw2-1",
+          toPortLabel: "xe-0/0/1"
+        },
+        {
+          id: "cable-host-a",
+          fromDeviceId: "device-leaf-sw1",
+          fromPortId: "port-leaf-sw1-2",
+          fromPortLabel: "xe-0/0/2",
+          toDeviceId: "device-server-01",
+          toPortId: "port-server-01-eth0",
+          toPortLabel: "eth0"
+        },
+        {
+          id: "cable-host-b",
+          fromDeviceId: "device-leaf-sw2",
+          fromPortId: "port-leaf-sw2-2",
+          fromPortLabel: "xe-0/0/2",
+          toDeviceId: "device-server-02",
+          toPortId: "port-server-02-eth0",
+          toPortLabel: "eth0"
+        },
+        {
+          id: "cable-power-a",
+          fromDeviceId: "device-pdu-a",
+          fromPortId: "port-pdu-a-feed1",
+          fromPortLabel: "feed-a",
+          toDeviceId: "device-server-01",
+          toPortId: "port-server-01-eth0",
+          toPortLabel: "psu-a"
+        }
+      ]
+    },
+    guidance: [
+      "Devices are positioned by explicit starting U and height.",
+      "Port chips are selectable and cable relationships stay explicit.",
+      "Basic cable rendering is intentionally lightweight until topology visualization lands."
+    ]
+  };
+}
 
 function createDomainResponse(): ApiOverviewResponse {
   const validPrefixes = referencePrefixes.filter((prefix) => validatePrefix(prefix).valid).length;
@@ -317,6 +554,12 @@ export function handleApiRequest(request: IncomingMessage, response: ServerRespo
 
   if (request.method === "GET" && requestUrl.pathname === "/api/overview") {
     sendJson(response, 200, createDomainResponse());
+
+    return;
+  }
+
+  if (request.method === "GET" && requestUrl.pathname === "/api/racks/demo") {
+    sendJson(response, 200, createRackResponse());
 
     return;
   }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,7 +1,9 @@
 import { startTransition, useDeferredValue, useEffect, useMemo, useState } from "react";
 
 import { shellNavigation, getNavigationItem, workspacePanels } from "../../../packages/ui/dist/index.js";
+import { RackElevation } from "./components/rack/RackElevation.js";
 import { useDomainOverview } from "./hooks/use-domain-overview.js";
+import { useRackElevation } from "./hooks/use-rack-elevation.js";
 
 function getSectionFromHash(): string {
   const hash = window.location.hash.replace(/^#/, "");
@@ -26,6 +28,7 @@ export function App() {
   const [activeSection, setActiveSection] = useState(() => getSectionFromHash());
   const deferredSection = useDeferredValue(activeSection);
   const { status, data, errorMessage, retry } = useDomainOverview();
+  const rack = useRackElevation();
 
   useEffect(() => {
     const onHashChange = () => {
@@ -65,6 +68,8 @@ export function App() {
     indicators: panel.indicators
   }));
   const visiblePanels = domainPanels.length > 0 ? domainPanels : fallbackPanels;
+  const showRackStage =
+    deferredSection === "dcim" && rack.status !== "error" && rack.data !== null;
 
   return (
     <div className="shell">
@@ -190,6 +195,36 @@ export function App() {
             <strong>{status === "ready" ? "Healthy fetch cycle" : status === "error" ? "Retry required" : "Loading"}</strong>
           </div>
         </section>
+
+        <section className="shell__workspace-detail">
+          {rack.status === "loading" ? (
+            <div className="shell__callout">
+              <strong>Loading rack elevation</strong>
+              <span>Building the grid, device positions, and cable overlays from the rack API contract.</span>
+              <div className="shell__loading-bar" aria-hidden="true" />
+            </div>
+          ) : null}
+
+          {rack.status === "error" ? (
+            <div className="shell__callout shell__callout--error">
+              <strong>Rack visualization unavailable</strong>
+              <span>{rack.errorMessage}</span>
+              <button type="button" className="shell__button" onClick={rack.retry}>
+                Retry rack fetch
+              </button>
+            </div>
+          ) : null}
+
+          {showRackStage ? (
+            <RackElevation
+              rack={rack.data.rack}
+              selectedDeviceId={rack.selectedDeviceId}
+              selectedPortId={rack.selectedPortId}
+              onDeviceSelect={rack.selectDevice}
+              onPortSelect={rack.selectPort}
+            />
+          ) : null}
+        </section>
       </main>
 
       <aside className="shell__context">
@@ -211,6 +246,9 @@ export function App() {
               "State transitions are isolated in src/state.",
               "React hooks own loading and retry orchestration."
             ]).map((notice) => (
+              <li key={notice}>{notice}</li>
+            ))}
+            {(showRackStage ? rack.data?.guidance ?? [] : []).map((notice) => (
               <li key={notice}>{notice}</li>
             ))}
           </ul>

--- a/apps/web/src/components/rack/RackElevation.tsx
+++ b/apps/web/src/components/rack/RackElevation.tsx
@@ -1,0 +1,158 @@
+import {
+  countConnectedPorts,
+  createRackUnitSlots,
+  findDevicePort,
+  getDeviceCoverageLabel,
+  type RackCableModel,
+  type RackModel
+} from "../../../../../packages/ui/dist/index.js";
+
+export interface RackElevationProps {
+  readonly rack: RackModel;
+  readonly selectedDeviceId: string | null;
+  readonly selectedPortId: string | null;
+  readonly onDeviceSelect: (deviceId: string) => void;
+  readonly onPortSelect: (deviceId: string, portId: string) => void;
+}
+
+function getCableForPort(cables: readonly RackCableModel[], deviceId: string, portId: string) {
+  return (
+    cables.find(
+      (cable) =>
+        (cable.fromDeviceId === deviceId && cable.fromPortId === portId) ||
+        (cable.toDeviceId === deviceId && cable.toPortId === portId)
+    ) ?? null
+  );
+}
+
+export function RackElevation({
+  rack,
+  selectedDeviceId,
+  selectedPortId,
+  onDeviceSelect,
+  onPortSelect
+}: RackElevationProps) {
+  const slots = createRackUnitSlots(rack);
+  const selectedDevice =
+    rack.devices.find((device) => device.id === selectedDeviceId) ?? rack.devices[0] ?? null;
+  const selectedPort =
+    selectedDevice && selectedPortId
+      ? findDevicePort(rack, selectedDevice.id, selectedPortId)
+      : selectedDevice?.ports[0] ?? null;
+  const selectedCable =
+    selectedDevice && selectedPort
+      ? getCableForPort(rack.cables, selectedDevice.id, selectedPort.id)
+      : null;
+
+  return (
+    <section className="rack-stage" aria-label="Rack elevation">
+      <div className="rack-stage__frame">
+        <header className="rack-stage__header">
+          <div>
+            <p className="shell__eyebrow">Rack elevation</p>
+            <h3>
+              {rack.siteName} / {rack.name}
+            </h3>
+          </div>
+          <div className="rack-stage__header-meta">
+            <span>{rack.totalUnits}U cabinet</span>
+            <strong>{rack.devices.length} devices placed</strong>
+          </div>
+        </header>
+
+        <div className="rack-stage__grid" role="grid" aria-label={`${rack.name} unit map`}>
+          {slots.map((slot) => {
+            const device = slot.occupant;
+            const selected = device?.id === selectedDevice?.id;
+
+            return (
+              <div key={slot.unit} className="rack-stage__slot" role="row">
+                <div className="rack-stage__u-marker" role="rowheader">
+                  U{slot.unit}
+                </div>
+                <div className="rack-stage__bay">
+                  {device ? (
+                    <button
+                      type="button"
+                      className={`rack-stage__device rack-stage__device--${device.tone}${selected ? " rack-stage__device--selected" : ""}${slot.occupantStart ? " rack-stage__device--start" : " rack-stage__device--continuation"}`}
+                      onClick={() => onDeviceSelect(device.id)}
+                    >
+                      {slot.occupantStart ? (
+                        <>
+                          <div className="rack-stage__device-head">
+                            <span>{device.name}</span>
+                            <small>{getDeviceCoverageLabel(device)}</small>
+                          </div>
+                          <div className="rack-stage__device-meta">
+                            <span>{device.role}</span>
+                            <strong>{countConnectedPorts(device)} active links</strong>
+                          </div>
+                        </>
+                      ) : (
+                        <span className="rack-stage__device-stub" aria-hidden="true" />
+                      )}
+                    </button>
+                  ) : (
+                    <div className="rack-stage__blank" aria-hidden="true" />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="rack-stage__detail">
+        <section className="rack-stage__detail-block">
+          <p className="shell__eyebrow">Selected device</p>
+          <h3>{selectedDevice?.name ?? "No device selected"}</h3>
+          <p>{selectedDevice?.role ?? "Choose a placed device to inspect its ports and cable mapping."}</p>
+
+          {selectedDevice ? (
+            <div className="rack-stage__port-map">
+              {selectedDevice.ports.map((port) => (
+                <button
+                  key={port.id}
+                  type="button"
+                  className={`rack-stage__port rack-stage__port--${port.status}${selectedPort?.id === port.id ? " rack-stage__port--selected" : ""}`}
+                  onClick={() => onPortSelect(selectedDevice.id, port.id)}
+                >
+                  <span>{port.label}</span>
+                  <small>{port.peerPortLabel ?? "unmapped"}</small>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rack-stage__detail-block">
+          <p className="shell__eyebrow">Cable view</p>
+          <h3>{selectedPort?.label ?? "Select a port"}</h3>
+          <p>
+            {selectedCable
+              ? `${selectedCable.fromPortLabel} to ${selectedCable.toPortLabel}`
+              : "Basic cable visualization shows the linked peer for the selected port."}
+          </p>
+          <div className="rack-stage__cable-trace">
+            <span className="rack-stage__cable-end">{selectedDevice?.name ?? "device"}</span>
+            <span className="rack-stage__cable-line" aria-hidden="true" />
+            <span className="rack-stage__cable-end">
+              {selectedCable
+                ? selectedCable.fromDeviceId === selectedDevice?.id
+                  ? selectedCable.toDeviceId
+                  : selectedCable.fromDeviceId
+                : "no-peer"}
+            </span>
+          </div>
+          <ul className="shell__notes">
+            {rack.cables.slice(0, 3).map((cable) => (
+              <li key={cable.id}>
+                {cable.fromPortLabel} {"->"} {cable.toPortLabel}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-rack-elevation.ts
+++ b/apps/web/src/hooks/use-rack-elevation.ts
@@ -1,0 +1,58 @@
+import { useEffect, useReducer, useState } from "react";
+
+import {
+  fetchRackElevation,
+  toRackErrorMessage,
+  type UiRackModel
+} from "../services/rack-elevation.js";
+import {
+  createInitialRackElevationState,
+  rackElevationReducer
+} from "../state/rack-elevation-state.js";
+
+export interface UseRackElevationResult {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiRackModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedDeviceId: string | null;
+  readonly selectedPortId: string | null;
+  readonly retry: () => void;
+  readonly selectDevice: (deviceId: string) => void;
+  readonly selectPort: (deviceId: string, portId: string) => void;
+}
+
+export function useRackElevation(): UseRackElevationResult {
+  const [state, dispatch] = useReducer(
+    rackElevationReducer,
+    undefined,
+    createInitialRackElevationState
+  );
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    dispatch({ type: "load_started" });
+
+    fetchRackElevation(controller.signal)
+      .then((payload) => {
+        dispatch({ type: "load_succeeded", payload });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        dispatch({ type: "load_failed", message: toRackErrorMessage(error) });
+      });
+
+    return () => controller.abort();
+  }, [attempt]);
+
+  return {
+    ...state,
+    retry: () => setAttempt((currentAttempt) => currentAttempt + 1),
+    selectDevice: (deviceId) => dispatch({ type: "device_selected", deviceId }),
+    selectPort: (deviceId, portId) => dispatch({ type: "port_selected", deviceId, portId })
+  };
+}

--- a/apps/web/src/services/rack-elevation.ts
+++ b/apps/web/src/services/rack-elevation.ts
@@ -1,0 +1,71 @@
+import { fetchJson, ApiClientError } from "./api-client.js";
+
+export interface ApiRackPortResponse {
+  readonly id: string;
+  readonly label: string;
+  readonly side: "left" | "right";
+  readonly status: "connected" | "available" | "disabled";
+  readonly cableId: string | null;
+  readonly peerPortLabel: string | null;
+}
+
+export interface ApiRackDeviceResponse {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly tone: "network" | "compute" | "power" | "storage";
+  readonly startUnit: number;
+  readonly heightUnits: number;
+  readonly ports: readonly ApiRackPortResponse[];
+}
+
+export interface ApiRackCableResponse {
+  readonly id: string;
+  readonly fromDeviceId: string;
+  readonly fromPortId: string;
+  readonly fromPortLabel: string;
+  readonly toDeviceId: string;
+  readonly toPortId: string;
+  readonly toPortLabel: string;
+}
+
+export interface ApiRackResponse {
+  readonly generatedAt: string;
+  readonly rack: {
+    readonly id: string;
+    readonly name: string;
+    readonly siteName: string;
+    readonly totalUnits: number;
+    readonly devices: readonly ApiRackDeviceResponse[];
+    readonly cables: readonly ApiRackCableResponse[];
+  };
+  readonly guidance: readonly string[];
+}
+
+export interface UiRackModel {
+  readonly syncedAt: string;
+  readonly rack: ApiRackResponse["rack"];
+  readonly guidance: readonly string[];
+}
+
+export function normalizeRackResponse(payload: ApiRackResponse): UiRackModel {
+  return {
+    syncedAt: payload.generatedAt,
+    rack: payload.rack,
+    guidance: payload.guidance
+  };
+}
+
+export async function fetchRackElevation(signal?: AbortSignal): Promise<UiRackModel> {
+  const payload = await fetchJson<ApiRackResponse>("/api/racks/demo", signal);
+
+  return normalizeRackResponse(payload);
+}
+
+export function toRackErrorMessage(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.message;
+  }
+
+  return "InfraLynx could not render the rack elevation payload.";
+}

--- a/apps/web/src/shell.css
+++ b/apps/web/src/shell.css
@@ -153,6 +153,11 @@ a {
   gap: 24px;
 }
 
+.shell__workspace-detail {
+  display: grid;
+  gap: 18px;
+}
+
 .shell__header,
 .shell__strip,
 .shell__hero,
@@ -426,6 +431,257 @@ a {
   font-size: 1.4rem;
 }
 
+.rack-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 22px;
+}
+
+.rack-stage__frame,
+.rack-stage__detail-block {
+  border: 1px solid rgba(57, 80, 106, 0.65);
+  background: rgba(23, 36, 52, 0.76);
+  box-shadow: var(--ui-shadow);
+  border-radius: 28px;
+}
+
+.rack-stage__frame {
+  padding: 24px;
+}
+
+.rack-stage__header,
+.rack-stage__header-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: end;
+}
+
+.rack-stage__header {
+  margin-bottom: 18px;
+}
+
+.rack-stage__header h3 {
+  margin: 8px 0 0;
+  font-size: 1.5rem;
+}
+
+.rack-stage__header-meta {
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.rack-stage__header-meta span {
+  color: var(--ui-text-muted);
+  font-size: 0.82rem;
+}
+
+.rack-stage__grid {
+  display: grid;
+  gap: 2px;
+  padding: 16px;
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(109, 166, 215, 0.08), rgba(10, 14, 20, 0.4)),
+    rgba(10, 14, 20, 0.75);
+  border: 1px solid rgba(57, 80, 106, 0.4);
+}
+
+.rack-stage__slot {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  gap: 10px;
+  align-items: stretch;
+  min-height: 22px;
+}
+
+.rack-stage__u-marker {
+  color: var(--ui-accent);
+  font-size: 0.76rem;
+  text-align: right;
+  padding-top: 3px;
+}
+
+.rack-stage__bay {
+  position: relative;
+}
+
+.rack-stage__blank {
+  height: 100%;
+  border-left: 1px solid rgba(57, 80, 106, 0.2);
+}
+
+.rack-stage__device {
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-left: 3px solid transparent;
+  border-radius: 10px;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  transition: transform 160ms ease, filter 160ms ease;
+}
+
+.rack-stage__device:hover {
+  transform: translateX(4px);
+  filter: brightness(1.06);
+}
+
+.rack-stage__device--start {
+  min-height: 48px;
+  padding: 10px 14px 10px 16px;
+}
+
+.rack-stage__device--continuation {
+  min-height: 22px;
+}
+
+.rack-stage__device--network {
+  background: linear-gradient(90deg, rgba(109, 166, 215, 0.38), rgba(109, 166, 215, 0.08));
+  border-left-color: rgba(109, 166, 215, 0.95);
+}
+
+.rack-stage__device--compute {
+  background: linear-gradient(90deg, rgba(215, 178, 109, 0.32), rgba(215, 178, 109, 0.08));
+  border-left-color: rgba(215, 178, 109, 0.9);
+}
+
+.rack-stage__device--power {
+  background: linear-gradient(90deg, rgba(139, 214, 167, 0.28), rgba(139, 214, 167, 0.08));
+  border-left-color: rgba(139, 214, 167, 0.92);
+}
+
+.rack-stage__device--storage {
+  background: linear-gradient(90deg, rgba(185, 196, 206, 0.28), rgba(185, 196, 206, 0.08));
+  border-left-color: rgba(185, 196, 206, 0.92);
+}
+
+.rack-stage__device--selected {
+  box-shadow: inset 0 0 0 1px rgba(247, 247, 244, 0.2);
+}
+
+.rack-stage__device-head,
+.rack-stage__device-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rack-stage__device-head span {
+  font-weight: 700;
+}
+
+.rack-stage__device-head small,
+.rack-stage__device-meta span {
+  color: var(--ui-text-muted);
+}
+
+.rack-stage__device-meta {
+  margin-top: 6px;
+  font-size: 0.82rem;
+}
+
+.rack-stage__device-stub {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.rack-stage__detail {
+  display: grid;
+  gap: 18px;
+}
+
+.rack-stage__detail-block {
+  padding: 22px;
+}
+
+.rack-stage__port-map {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.rack-stage__port {
+  padding: 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(57, 80, 106, 0.45);
+  background: rgba(12, 19, 29, 0.42);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rack-stage__port span,
+.rack-stage__port small {
+  display: block;
+}
+
+.rack-stage__port span {
+  font-weight: 700;
+}
+
+.rack-stage__port small {
+  margin-top: 5px;
+  color: var(--ui-text-muted);
+}
+
+.rack-stage__port--connected {
+  border-color: rgba(109, 166, 215, 0.55);
+}
+
+.rack-stage__port--available {
+  border-color: rgba(139, 214, 167, 0.4);
+}
+
+.rack-stage__port--disabled {
+  border-color: rgba(185, 196, 206, 0.3);
+  opacity: 0.7;
+}
+
+.rack-stage__port--selected {
+  background: rgba(109, 166, 215, 0.12);
+  transform: translateY(-2px);
+}
+
+.rack-stage__cable-trace {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  margin: 18px 0 12px;
+}
+
+.rack-stage__cable-end {
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(12, 19, 29, 0.5);
+  border: 1px solid rgba(57, 80, 106, 0.45);
+  font-size: 0.84rem;
+}
+
+.rack-stage__cable-line {
+  height: 2px;
+  background: linear-gradient(90deg, var(--ui-accent-cool), var(--ui-accent));
+  position: relative;
+}
+
+.rack-stage__cable-line::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: -4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--ui-accent);
+  box-shadow: 0 0 14px rgba(215, 178, 109, 0.45);
+}
+
 @keyframes shell-fade {
   from {
     opacity: 0;
@@ -465,6 +721,10 @@ a {
   }
 
   .shell__metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .rack-stage {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/state/rack-elevation-state.ts
+++ b/apps/web/src/state/rack-elevation-state.ts
@@ -1,0 +1,61 @@
+import type { UiRackModel } from "../services/rack-elevation.js";
+
+export interface RackElevationState {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiRackModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedDeviceId: string | null;
+  readonly selectedPortId: string | null;
+}
+
+export type RackElevationAction =
+  | { readonly type: "load_started" }
+  | { readonly type: "load_succeeded"; readonly payload: UiRackModel }
+  | { readonly type: "load_failed"; readonly message: string }
+  | { readonly type: "device_selected"; readonly deviceId: string }
+  | { readonly type: "port_selected"; readonly deviceId: string; readonly portId: string };
+
+export function createInitialRackElevationState(): RackElevationState {
+  return {
+    status: "idle",
+    data: null,
+    errorMessage: null,
+    selectedDeviceId: null,
+    selectedPortId: null
+  };
+}
+
+export function rackElevationReducer(
+  state: RackElevationState,
+  action: RackElevationAction
+): RackElevationState {
+  switch (action.type) {
+    case "load_started":
+      return { ...state, status: "loading", errorMessage: null };
+    case "load_succeeded":
+      return {
+        status: "ready",
+        data: action.payload,
+        errorMessage: null,
+        selectedDeviceId: action.payload.rack.devices[0]?.id ?? null,
+        selectedPortId: action.payload.rack.devices[0]?.ports[0]?.id ?? null
+      };
+    case "load_failed":
+      return { ...state, status: "error", errorMessage: action.message };
+    case "device_selected":
+      return {
+        ...state,
+        selectedDeviceId: action.deviceId,
+        selectedPortId:
+          state.data?.rack.devices.find((device) => device.id === action.deviceId)?.ports[0]?.id ?? null
+      };
+    case "port_selected":
+      return {
+        ...state,
+        selectedDeviceId: action.deviceId,
+        selectedPortId: action.portId
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -74,3 +74,5 @@ export function getNavigationItem(sectionId: string): NavigationItem {
 
   return match ?? shellNavigation[0];
 }
+
+export * from "./rack-system/index.js";

--- a/packages/ui/src/rack-system/index.ts
+++ b/packages/ui/src/rack-system/index.ts
@@ -1,0 +1,97 @@
+export type RackDeviceTone = "network" | "compute" | "power" | "storage";
+export type RackPortStatus = "connected" | "available" | "disabled";
+
+export interface RackPortModel {
+  readonly id: string;
+  readonly label: string;
+  readonly side: "left" | "right";
+  readonly status: RackPortStatus;
+  readonly cableId: string | null;
+  readonly peerPortLabel: string | null;
+}
+
+export interface RackDevicePlacementModel {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly tone: RackDeviceTone;
+  readonly startUnit: number;
+  readonly heightUnits: number;
+  readonly ports: readonly RackPortModel[];
+}
+
+export interface RackCableModel {
+  readonly id: string;
+  readonly fromDeviceId: string;
+  readonly fromPortId: string;
+  readonly fromPortLabel: string;
+  readonly toDeviceId: string;
+  readonly toPortId: string;
+  readonly toPortLabel: string;
+}
+
+export interface RackModel {
+  readonly id: string;
+  readonly name: string;
+  readonly siteName: string;
+  readonly totalUnits: number;
+  readonly devices: readonly RackDevicePlacementModel[];
+  readonly cables: readonly RackCableModel[];
+}
+
+export interface RackUnitSlot {
+  readonly unit: number;
+  readonly occupant: RackDevicePlacementModel | null;
+  readonly occupantStart: boolean;
+}
+
+export function sortRackDevicesByPosition(devices: readonly RackDevicePlacementModel[]) {
+  return [...devices].sort((left, right) => {
+    if (left.startUnit !== right.startUnit) {
+      return right.startUnit - left.startUnit;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function createRackUnitSlots(rack: RackModel): readonly RackUnitSlot[] {
+  const orderedDevices = sortRackDevicesByPosition(rack.devices);
+  const slots: RackUnitSlot[] = [];
+
+  for (let unit = rack.totalUnits; unit >= 1; unit -= 1) {
+    const occupant =
+      orderedDevices.find(
+        (device) => unit <= device.startUnit && unit > device.startUnit - device.heightUnits
+      ) ?? null;
+
+    slots.push({
+      unit,
+      occupant,
+      occupantStart: occupant !== null && unit === occupant.startUnit
+    });
+  }
+
+  return slots;
+}
+
+export function getDeviceCoverageLabel(device: RackDevicePlacementModel): string {
+  const topUnit = device.startUnit;
+  const bottomUnit = device.startUnit - device.heightUnits + 1;
+
+  return `${topUnit}U-${bottomUnit}U`;
+}
+
+export function countConnectedPorts(device: RackDevicePlacementModel): number {
+  return device.ports.filter((port) => port.status === "connected").length;
+}
+
+export function findDevicePort(
+  rack: RackModel,
+  deviceId: string,
+  portId: string
+): RackPortModel | null {
+  const device = rack.devices.find((candidate) => candidate.id === deviceId);
+
+  return device?.ports.find((port) => port.id === portId) ?? null;
+}

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -27,7 +27,12 @@ import {
   validateInterfaceVlanBinding,
   validatePrefixHierarchyBinding
 } from "../../packages/network-domain/dist/index.js";
-import { shellNavigation, workspacePanels } from "../../packages/ui/dist/index.js";
+import {
+  createRackUnitSlots,
+  getDeviceCoverageLabel,
+  shellNavigation,
+  workspacePanels
+} from "../../packages/ui/dist/index.js";
 import {
   canAllocateChildPrefix,
   createVlanDirectory,
@@ -213,6 +218,43 @@ test("ui scaffolds expose navigation and workspace panels", () => {
   assert.equal(shellNavigation.length >= 6, true);
   assert.equal(workspacePanels.some((panel) => panel.id === "dcim"), true);
   assert.equal(shellNavigation[0]?.label, "Overview");
+});
+
+test("rack system scaffolds create deterministic device slots", () => {
+  const slots = createRackUnitSlots({
+    id: "rack-a1",
+    name: "A1",
+    siteName: "Dallas One",
+    totalUnits: 6,
+    devices: [
+      {
+        id: "device-top",
+        name: "leaf-sw1",
+        role: "Top-of-rack switch",
+        tone: "network",
+        startUnit: 6,
+        heightUnits: 2,
+        ports: []
+      },
+      {
+        id: "device-mid",
+        name: "compute-01",
+        role: "Application host",
+        tone: "compute",
+        startUnit: 3,
+        heightUnits: 2,
+        ports: []
+      }
+    ],
+    cables: []
+  });
+
+  assert.equal(slots.length, 6);
+  assert.equal(slots[0]?.occupant?.id, "device-top");
+  assert.equal(slots[0]?.occupantStart, true);
+  assert.equal(slots[1]?.occupant?.id, "device-top");
+  assert.equal(getDeviceCoverageLabel(slots[0]?.occupant), "6U-5U");
+  assert.equal(slots[3]?.occupant?.id, "device-mid");
 });
 
 test("cross-domain bindings stay explicit and ID-based", () => {


### PR DESCRIPTION
## Summary
- add reusable rack-system helpers to @infralynx/ui
- expose a demo rack payload from the API
- render an interactive rack elevation with device, port, and cable selection in the web shell

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test
- runtime smoke test for /api/racks/demo