### PR TITLE
Chunk 15: topology graph visualization

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { type Rack, type Site, validateCable, validateRackPosition } from "../..
 import { platformBoundaries } from "../../../packages/domain-core/dist/index.js";
 import { type IpAddress, type Prefix, type Vlan, validateIpAddress, validatePrefix } from "../../../packages/ipam-domain/dist/index.js";
 import {
+  createTopologyView,
   tracePath,
   validateInterfaceIpBinding,
   validateInterfaceVlanBinding,
@@ -82,6 +83,12 @@ export interface ApiRackResponse {
     readonly devices: readonly ApiRackDeviceResponse[];
     readonly cables: readonly ApiRackCableResponse[];
   };
+  readonly guidance: readonly string[];
+}
+
+export interface ApiTopologyResponse {
+  readonly generatedAt: string;
+  readonly graph: ReturnType<typeof createTopologyView>;
   readonly guidance: readonly string[];
 }
 
@@ -353,6 +360,153 @@ function createRackResponse(): ApiRackResponse {
   };
 }
 
+function createTopologyResponse(): ApiTopologyResponse {
+  const graph = createTopologyView(
+    [
+      {
+        id: "device-spine-sw1",
+        name: "spine-sw1",
+        role: "Spine",
+        tone: "network",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["spine-sw1:xe-0/0/1", "spine-sw1:xe-0/0/2", "spine-sw1:xe-0/0/3"],
+        vlanIds: ["vlan-120", "vlan-410"]
+      },
+      {
+        id: "device-leaf-sw1",
+        name: "leaf-sw1",
+        role: "Top-of-rack switch",
+        tone: "network",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["leaf-sw1:xe-0/0/1", "leaf-sw1:xe-0/0/2", "leaf-sw1:xe-0/0/48"],
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "device-leaf-sw2",
+        name: "leaf-sw2",
+        role: "Top-of-rack switch",
+        tone: "network",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["leaf-sw2:xe-0/0/1", "leaf-sw2:xe-0/0/2", "leaf-sw2:xe-0/0/48"],
+        vlanIds: ["vlan-120", "vlan-410"]
+      },
+      {
+        id: "device-compute-01",
+        name: "compute-01",
+        role: "Application host",
+        tone: "compute",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["compute-01:eth0", "compute-01:eth1"],
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "device-storage-01",
+        name: "storage-01",
+        role: "Storage host",
+        tone: "storage",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["storage-01:eth0", "storage-01:eth1"],
+        vlanIds: ["vlan-410"]
+      },
+      {
+        id: "device-pdu-a",
+        name: "pdu-a",
+        role: "Power distribution",
+        tone: "power",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["pdu-a:feed-a", "pdu-a:feed-b"],
+        vlanIds: []
+      },
+      {
+        id: "device-leaf-phx1",
+        name: "leaf-phx1",
+        role: "Top-of-rack switch",
+        tone: "network",
+        siteId: "site-phx1",
+        siteName: "Phoenix One",
+        interfaceIds: ["leaf-phx1:xe-0/0/1", "leaf-phx1:xe-0/0/2"],
+        vlanIds: ["vlan-220"]
+      },
+      {
+        id: "device-compute-phx1",
+        name: "compute-phx1",
+        role: "Application host",
+        tone: "compute",
+        siteId: "site-phx1",
+        siteName: "Phoenix One",
+        interfaceIds: ["compute-phx1:eth0"],
+        vlanIds: ["vlan-220"]
+      }
+    ],
+    [
+      {
+        id: "cable-spine-leaf1",
+        fromDeviceId: "device-spine-sw1",
+        toDeviceId: "device-leaf-sw1",
+        kind: "cable-link",
+        label: "uplink-a",
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "cable-spine-leaf2",
+        fromDeviceId: "device-spine-sw1",
+        toDeviceId: "device-leaf-sw2",
+        kind: "cable-link",
+        label: "uplink-b",
+        vlanIds: ["vlan-120", "vlan-410"]
+      },
+      {
+        id: "cable-leaf1-host1",
+        fromDeviceId: "device-leaf-sw1",
+        toDeviceId: "device-compute-01",
+        kind: "l2-adjacency",
+        label: "server access",
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "cable-leaf2-storage1",
+        fromDeviceId: "device-leaf-sw2",
+        toDeviceId: "device-storage-01",
+        kind: "vlan-propagation",
+        label: "storage fabric",
+        vlanIds: ["vlan-410"]
+      },
+      {
+        id: "cable-pdu-host1",
+        fromDeviceId: "device-pdu-a",
+        toDeviceId: "device-compute-01",
+        kind: "cable-link",
+        label: "power feed",
+        vlanIds: []
+      },
+      {
+        id: "cable-phx-leaf-host",
+        fromDeviceId: "device-leaf-phx1",
+        toDeviceId: "device-compute-phx1",
+        kind: "l3-adjacency",
+        label: "remote workload",
+        vlanIds: ["vlan-220"]
+      }
+    ]
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    graph,
+    guidance: [
+      "Topology edges are explicit and never inferred from naming.",
+      "Layout is deterministic so the same inventory produces the same visual ordering.",
+      "Filtering is applied against site, role, and VLAN tags before the graph reaches the canvas."
+    ]
+  };
+}
+
 function createDomainResponse(): ApiOverviewResponse {
   const validPrefixes = referencePrefixes.filter((prefix) => validatePrefix(prefix).valid).length;
   const validAddresses = referenceAddresses.filter((address) => validateIpAddress(address).valid).length;
@@ -560,6 +714,12 @@ export function handleApiRequest(request: IncomingMessage, response: ServerRespo
 
   if (request.method === "GET" && requestUrl.pathname === "/api/racks/demo") {
     sendJson(response, 200, createRackResponse());
+
+    return;
+  }
+
+  if (request.method === "GET" && requestUrl.pathname === "/api/topology/demo") {
+    sendJson(response, 200, createTopologyResponse());
 
     return;
   }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -2,8 +2,10 @@ import { startTransition, useDeferredValue, useEffect, useMemo, useState } from 
 
 import { shellNavigation, getNavigationItem, workspacePanels } from "../../../packages/ui/dist/index.js";
 import { RackElevation } from "./components/rack/RackElevation.js";
+import { TopologyGraph } from "./components/topology/TopologyGraph.js";
 import { useDomainOverview } from "./hooks/use-domain-overview.js";
 import { useRackElevation } from "./hooks/use-rack-elevation.js";
+import { useTopologyGraph } from "./hooks/use-topology-graph.js";
 
 function getSectionFromHash(): string {
   const hash = window.location.hash.replace(/^#/, "");
@@ -29,6 +31,7 @@ export function App() {
   const deferredSection = useDeferredValue(activeSection);
   const { status, data, errorMessage, retry } = useDomainOverview();
   const rack = useRackElevation();
+  const topology = useTopologyGraph();
 
   useEffect(() => {
     const onHashChange = () => {
@@ -70,6 +73,8 @@ export function App() {
   const visiblePanels = domainPanels.length > 0 ? domainPanels : fallbackPanels;
   const showRackStage =
     deferredSection === "dcim" && rack.status !== "error" && rack.data !== null;
+  const showTopologyStage =
+    deferredSection === "operations" && topology.status !== "error" && topology.data !== null;
 
   return (
     <div className="shell">
@@ -224,6 +229,41 @@ export function App() {
               onPortSelect={rack.selectPort}
             />
           ) : null}
+
+          {topology.status === "loading" && deferredSection === "operations" ? (
+            <div className="shell__callout">
+              <strong>Loading topology graph</strong>
+              <span>Assembling the filtered graph model, node layout, and interactive viewport state.</span>
+              <div className="shell__loading-bar" aria-hidden="true" />
+            </div>
+          ) : null}
+
+          {topology.status === "error" && deferredSection === "operations" ? (
+            <div className="shell__callout shell__callout--error">
+              <strong>Topology visualization unavailable</strong>
+              <span>{topology.errorMessage}</span>
+              <button type="button" className="shell__button" onClick={topology.retry}>
+                Retry topology fetch
+              </button>
+            </div>
+          ) : null}
+
+          {showTopologyStage ? (
+            <TopologyGraph
+              graph={topology.data.graph}
+              selectedNodeId={topology.selectedNodeId}
+              filter={topology.filter}
+              filterOptions={topology.data.options}
+              viewport={topology.viewport}
+              syncedAt={topology.data.syncedAt}
+              onSelectNode={topology.selectNode}
+              onFilterChange={topology.updateFilter}
+              onViewportChange={topology.updateViewport}
+              onZoomIn={topology.zoomIn}
+              onZoomOut={topology.zoomOut}
+              onResetViewport={topology.resetViewport}
+            />
+          ) : null}
         </section>
       </main>
 
@@ -249,6 +289,9 @@ export function App() {
               <li key={notice}>{notice}</li>
             ))}
             {(showRackStage ? rack.data?.guidance ?? [] : []).map((notice) => (
+              <li key={notice}>{notice}</li>
+            ))}
+            {(showTopologyStage ? topology.data?.guidance ?? [] : []).map((notice) => (
               <li key={notice}>{notice}</li>
             ))}
           </ul>

--- a/apps/web/src/components/topology/TopologyGraph.tsx
+++ b/apps/web/src/components/topology/TopologyGraph.tsx
@@ -1,0 +1,277 @@
+import { useState } from "react";
+
+import {
+  findConnectedEdges,
+  findTopologyNode,
+  type TopologyFilterModel,
+  type TopologyGraphModel
+} from "../../../../../packages/ui/dist/index.js";
+import type { TopologyViewport } from "../../state/topology-graph-state.js";
+
+export interface TopologyGraphProps {
+  readonly graph: TopologyGraphModel;
+  readonly selectedNodeId: string | null;
+  readonly filter: TopologyFilterModel;
+  readonly filterOptions: {
+    readonly sites: readonly { readonly id: string; readonly label: string }[];
+    readonly roles: readonly string[];
+    readonly vlans: readonly string[];
+  };
+  readonly viewport: TopologyViewport;
+  readonly syncedAt: string;
+  readonly onSelectNode: (nodeId: string) => void;
+  readonly onFilterChange: (filter: TopologyFilterModel) => void;
+  readonly onViewportChange: (viewport: TopologyViewport) => void;
+  readonly onZoomIn: () => void;
+  readonly onZoomOut: () => void;
+  readonly onResetViewport: () => void;
+}
+
+function getNodeRadius(interfaceCount: number): number {
+  return Math.min(34, 18 + interfaceCount * 1.4);
+}
+
+function formatEdgeKind(kind: string): string {
+  return kind.replace(/-/g, " ");
+}
+
+export function TopologyGraph({
+  graph,
+  selectedNodeId,
+  filter,
+  filterOptions,
+  viewport,
+  syncedAt,
+  onSelectNode,
+  onFilterChange,
+  onViewportChange,
+  onZoomIn,
+  onZoomOut,
+  onResetViewport
+}: TopologyGraphProps) {
+  const selectedNode = findTopologyNode(graph, selectedNodeId);
+  const connectedEdges = findConnectedEdges(graph, selectedNodeId);
+  const [dragOrigin, setDragOrigin] = useState<{
+    pointerX: number;
+    pointerY: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+
+  return (
+    <section className="topology-stage" aria-label="Topology graph">
+      <div className="topology-stage__frame">
+        <header className="topology-stage__header">
+          <div>
+            <p className="shell__eyebrow">Topology graph</p>
+            <h3>Operational network view</h3>
+          </div>
+          <div className="topology-stage__header-meta">
+            <span>{graph.nodes.length} visible devices</span>
+            <strong>
+              {graph.edges.length} links / {new Date(syncedAt).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
+            </strong>
+          </div>
+        </header>
+
+        <div className="topology-stage__toolbar">
+          <label className="topology-stage__filter">
+            <span>Site</span>
+            <select
+              value={filter.siteId ?? ""}
+              onChange={(event) =>
+                onFilterChange({
+                  ...filter,
+                  siteId: event.target.value || null
+                })
+              }
+            >
+              <option value="">All sites</option>
+              {filterOptions.sites.map((site) => (
+                <option key={site.id} value={site.id}>
+                  {site.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="topology-stage__filter">
+            <span>Role</span>
+            <select
+              value={filter.role ?? ""}
+              onChange={(event) =>
+                onFilterChange({
+                  ...filter,
+                  role: event.target.value || null
+                })
+              }
+            >
+              <option value="">All roles</option>
+              {filterOptions.roles.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="topology-stage__filter">
+            <span>VLAN</span>
+            <select
+              value={filter.vlanId ?? ""}
+              onChange={(event) =>
+                onFilterChange({
+                  ...filter,
+                  vlanId: event.target.value || null
+                })
+              }
+            >
+              <option value="">Any VLAN</option>
+              {filterOptions.vlans.map((vlanId) => (
+                <option key={vlanId} value={vlanId}>
+                  {vlanId}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="topology-stage__toolbar-actions">
+            <button type="button" className="shell__button" onClick={onZoomOut}>
+              Zoom out
+            </button>
+            <button type="button" className="shell__button" onClick={onZoomIn}>
+              Zoom in
+            </button>
+            <button type="button" className="shell__button" onClick={onResetViewport}>
+              Reset view
+            </button>
+          </div>
+        </div>
+
+        <div
+          className="topology-stage__viewport"
+          onPointerDown={(event) =>
+            setDragOrigin({
+              pointerX: event.clientX,
+              pointerY: event.clientY,
+              offsetX: viewport.offsetX,
+              offsetY: viewport.offsetY
+            })
+          }
+          onPointerMove={(event) => {
+            if (!dragOrigin) {
+              return;
+            }
+
+            onViewportChange({
+              ...viewport,
+              offsetX: dragOrigin.offsetX + event.clientX - dragOrigin.pointerX,
+              offsetY: dragOrigin.offsetY + event.clientY - dragOrigin.pointerY
+            });
+          }}
+          onPointerUp={() => setDragOrigin(null)}
+          onPointerLeave={() => setDragOrigin(null)}
+        >
+          <svg className="topology-stage__canvas" viewBox="0 0 1200 720" role="img" aria-label="Network topology graph">
+            <g transform={`translate(${viewport.offsetX} ${viewport.offsetY}) scale(${viewport.scale})`}>
+              {graph.edges.map((edge) => {
+                const fromNode = graph.nodes.find((node) => node.id === edge.fromNodeId);
+                const toNode = graph.nodes.find((node) => node.id === edge.toNodeId);
+
+                if (!fromNode || !toNode) {
+                  return null;
+                }
+
+                const edgeSelected = edge.fromNodeId === selectedNodeId || edge.toNodeId === selectedNodeId;
+
+                return (
+                  <g key={edge.id}>
+                    <line
+                      className={edgeSelected ? "topology-stage__edge topology-stage__edge--selected" : "topology-stage__edge"}
+                      x1={fromNode.position.x}
+                      y1={fromNode.position.y}
+                      x2={toNode.position.x}
+                      y2={toNode.position.y}
+                    />
+                    <text
+                      className="topology-stage__edge-label"
+                      x={(fromNode.position.x + toNode.position.x) / 2}
+                      y={(fromNode.position.y + toNode.position.y) / 2 - 8}
+                      textAnchor="middle"
+                    >
+                      {edge.label}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {graph.nodes.map((node) => {
+                const selected = node.id === selectedNodeId;
+
+                return (
+                  <g
+                    key={node.id}
+                    className="topology-stage__node-group"
+                    transform={`translate(${node.position.x} ${node.position.y})`}
+                    onClick={() => onSelectNode(node.id)}
+                  >
+                    <circle
+                      className={`topology-stage__node topology-stage__node--${node.tone}${selected ? " topology-stage__node--selected" : ""}`}
+                      r={getNodeRadius(node.interfaceCount)}
+                    />
+                    <text className="topology-stage__node-title" textAnchor="middle" y={4}>
+                      {node.label}
+                    </text>
+                    <text className="topology-stage__node-meta" textAnchor="middle" y={getNodeRadius(node.interfaceCount) + 18}>
+                      {node.role}
+                    </text>
+                  </g>
+                );
+              })}
+            </g>
+          </svg>
+        </div>
+      </div>
+
+      <div className="topology-stage__detail">
+        <section className="topology-stage__detail-block">
+          <p className="shell__eyebrow">Selected node</p>
+          <h3>{selectedNode?.label ?? "No device selected"}</h3>
+          <p>{selectedNode?.role ?? "Choose a device to inspect its topology relationships and link metadata."}</p>
+          {selectedNode ? (
+            <div className="topology-stage__node-summary">
+              <div className="shell__metric">
+                <span>Site</span>
+                <strong>{selectedNode.siteName}</strong>
+              </div>
+              <div className="shell__metric">
+                <span>Interfaces</span>
+                <strong>{selectedNode.interfaceCount}</strong>
+              </div>
+              <div className="shell__metric">
+                <span>VLANs</span>
+                <strong>{selectedNode.vlanIds.join(", ") || "none"}</strong>
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="topology-stage__detail-block">
+          <p className="shell__eyebrow">Link relationships</p>
+          <h3>{connectedEdges.length} connected paths</h3>
+          <ul className="shell__notes">
+            {connectedEdges.length > 0 ? (
+              connectedEdges.map((edge) => (
+                <li key={edge.id}>
+                  {edge.label} / {formatEdgeKind(edge.kind)}
+                </li>
+              ))
+            ) : (
+              <li>No visible links match the current filter.</li>
+            )}
+          </ul>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-topology-graph.ts
+++ b/apps/web/src/hooks/use-topology-graph.ts
@@ -1,0 +1,69 @@
+import { useEffect, useReducer, useState } from "react";
+
+import { type TopologyFilterModel } from "../../../../packages/ui/dist/index.js";
+import {
+  fetchTopologyGraph,
+  toTopologyErrorMessage,
+  type UiTopologyModel
+} from "../services/topology-graph.js";
+import {
+  createInitialTopologyGraphState,
+  topologyGraphReducer,
+  type TopologyViewport
+} from "../state/topology-graph-state.js";
+
+export interface UseTopologyGraphResult {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiTopologyModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedNodeId: string | null;
+  readonly filter: TopologyFilterModel;
+  readonly viewport: TopologyViewport;
+  readonly retry: () => void;
+  readonly selectNode: (nodeId: string) => void;
+  readonly updateFilter: (filter: TopologyFilterModel) => void;
+  readonly updateViewport: (viewport: TopologyViewport) => void;
+  readonly zoomIn: () => void;
+  readonly zoomOut: () => void;
+  readonly resetViewport: () => void;
+}
+
+export function useTopologyGraph(): UseTopologyGraphResult {
+  const [state, dispatch] = useReducer(
+    topologyGraphReducer,
+    undefined,
+    createInitialTopologyGraphState
+  );
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    dispatch({ type: "load_started" });
+
+    fetchTopologyGraph(controller.signal)
+      .then((payload) => {
+        dispatch({ type: "load_succeeded", payload });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        dispatch({ type: "load_failed", message: toTopologyErrorMessage(error) });
+      });
+
+    return () => controller.abort();
+  }, [attempt]);
+
+  return {
+    ...state,
+    retry: () => setAttempt((currentAttempt) => currentAttempt + 1),
+    selectNode: (nodeId) => dispatch({ type: "node_selected", nodeId }),
+    updateFilter: (filter) => dispatch({ type: "filter_changed", filter }),
+    updateViewport: (viewport) => dispatch({ type: "viewport_changed", viewport }),
+    zoomIn: () => dispatch({ type: "zoom_in" }),
+    zoomOut: () => dispatch({ type: "zoom_out" }),
+    resetViewport: () => dispatch({ type: "viewport_reset" })
+  };
+}

--- a/apps/web/src/services/topology-graph.ts
+++ b/apps/web/src/services/topology-graph.ts
@@ -1,0 +1,57 @@
+import { fetchJson, ApiClientError } from "./api-client.js";
+
+import {
+  collectTopologyFilterOptions,
+  createDefaultTopologyFilter,
+  filterTopologyGraph,
+  type TopologyFilterModel,
+  type TopologyGraphEdge,
+  type TopologyGraphModel,
+  type TopologyGraphNode
+} from "../../../../packages/ui/dist/index.js";
+
+export type ApiTopologyNodeResponse = TopologyGraphNode;
+
+export type ApiTopologyEdgeResponse = TopologyGraphEdge;
+
+export interface ApiTopologyResponse {
+  readonly generatedAt: string;
+  readonly graph: TopologyGraphModel;
+  readonly guidance: readonly string[];
+}
+
+export interface UiTopologyModel {
+  readonly syncedAt: string;
+  readonly fullGraph: TopologyGraphModel;
+  readonly graph: TopologyGraphModel;
+  readonly filter: TopologyFilterModel;
+  readonly options: ReturnType<typeof collectTopologyFilterOptions>;
+  readonly guidance: readonly string[];
+}
+
+export function normalizeTopologyResponse(payload: ApiTopologyResponse): UiTopologyModel {
+  const filter = createDefaultTopologyFilter();
+
+  return {
+    syncedAt: payload.generatedAt,
+    fullGraph: payload.graph,
+    graph: filterTopologyGraph(payload.graph, filter),
+    filter,
+    options: collectTopologyFilterOptions(payload.graph),
+    guidance: payload.guidance
+  };
+}
+
+export async function fetchTopologyGraph(signal?: AbortSignal): Promise<UiTopologyModel> {
+  const payload = await fetchJson<ApiTopologyResponse>("/api/topology/demo", signal);
+
+  return normalizeTopologyResponse(payload);
+}
+
+export function toTopologyErrorMessage(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.message;
+  }
+
+  return "InfraLynx could not render the topology graph payload.";
+}

--- a/apps/web/src/shell.css
+++ b/apps/web/src/shell.css
@@ -682,6 +682,191 @@ a {
   box-shadow: 0 0 14px rgba(215, 178, 109, 0.45);
 }
 
+.topology-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+  gap: 22px;
+}
+
+.topology-stage__frame,
+.topology-stage__detail-block {
+  border: 1px solid rgba(57, 80, 106, 0.65);
+  background: rgba(23, 36, 52, 0.76);
+  box-shadow: var(--ui-shadow);
+  border-radius: 28px;
+}
+
+.topology-stage__frame {
+  padding: 24px;
+}
+
+.topology-stage__header,
+.topology-stage__header-meta,
+.topology-stage__toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.topology-stage__header {
+  align-items: end;
+  margin-bottom: 16px;
+}
+
+.topology-stage__header h3 {
+  margin: 8px 0 0;
+  font-size: 1.5rem;
+}
+
+.topology-stage__header-meta {
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.topology-stage__header-meta span {
+  color: var(--ui-text-muted);
+  font-size: 0.82rem;
+}
+
+.topology-stage__toolbar {
+  flex-wrap: wrap;
+  align-items: end;
+  margin-bottom: 16px;
+}
+
+.topology-stage__filter {
+  display: grid;
+  gap: 6px;
+  min-width: 140px;
+}
+
+.topology-stage__filter span {
+  color: var(--ui-text-muted);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.topology-stage__filter select {
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(57, 80, 106, 0.55);
+  background: rgba(12, 19, 29, 0.58);
+  color: var(--ui-text);
+  font: inherit;
+}
+
+.topology-stage__toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.topology-stage__toolbar-actions .shell__button {
+  margin-top: 0;
+}
+
+.topology-stage__viewport {
+  border-radius: 26px;
+  overflow: hidden;
+  border: 1px solid rgba(57, 80, 106, 0.45);
+  background:
+    radial-gradient(circle at top, rgba(109, 166, 215, 0.16), transparent 40%),
+    linear-gradient(180deg, rgba(11, 18, 26, 0.96), rgba(17, 28, 40, 0.98));
+  cursor: grab;
+  min-height: 620px;
+}
+
+.topology-stage__viewport:active {
+  cursor: grabbing;
+}
+
+.topology-stage__canvas {
+  width: 100%;
+  height: 620px;
+  display: block;
+}
+
+.topology-stage__edge {
+  stroke: rgba(109, 166, 215, 0.55);
+  stroke-width: 2.5;
+}
+
+.topology-stage__edge--selected {
+  stroke: rgba(215, 178, 109, 0.88);
+  stroke-width: 3.5;
+}
+
+.topology-stage__edge-label {
+  fill: var(--ui-text-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.topology-stage__node-group {
+  cursor: pointer;
+}
+
+.topology-stage__node {
+  stroke: rgba(247, 247, 244, 0.12);
+  stroke-width: 1.5;
+  transition: transform 160ms ease, stroke 160ms ease;
+}
+
+.topology-stage__node--network {
+  fill: rgba(109, 166, 215, 0.28);
+}
+
+.topology-stage__node--compute {
+  fill: rgba(215, 178, 109, 0.24);
+}
+
+.topology-stage__node--power {
+  fill: rgba(139, 214, 167, 0.24);
+}
+
+.topology-stage__node--storage {
+  fill: rgba(185, 196, 206, 0.22);
+}
+
+.topology-stage__node--selected {
+  stroke: rgba(215, 178, 109, 0.9);
+  stroke-width: 3;
+}
+
+.topology-stage__node-title,
+.topology-stage__node-meta {
+  pointer-events: none;
+}
+
+.topology-stage__node-title {
+  fill: var(--ui-text);
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+
+.topology-stage__node-meta {
+  fill: var(--ui-text-muted);
+  font-size: 0.66rem;
+}
+
+.topology-stage__detail {
+  display: grid;
+  gap: 18px;
+}
+
+.topology-stage__detail-block {
+  padding: 22px;
+}
+
+.topology-stage__node-summary {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
 @keyframes shell-fade {
   from {
     opacity: 0;
@@ -725,6 +910,10 @@ a {
   }
 
   .rack-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .topology-stage {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/state/topology-graph-state.ts
+++ b/apps/web/src/state/topology-graph-state.ts
@@ -1,0 +1,135 @@
+import {
+  createDefaultTopologyFilter,
+  filterTopologyGraph,
+  type TopologyFilterModel
+} from "../../../../packages/ui/dist/index.js";
+import type { UiTopologyModel } from "../services/topology-graph.js";
+
+export interface TopologyViewport {
+  readonly scale: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+}
+
+export interface TopologyGraphState {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly data: UiTopologyModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedNodeId: string | null;
+  readonly filter: TopologyFilterModel;
+  readonly viewport: TopologyViewport;
+}
+
+export type TopologyGraphAction =
+  | { readonly type: "load_started" }
+  | { readonly type: "load_succeeded"; readonly payload: UiTopologyModel }
+  | { readonly type: "load_failed"; readonly message: string }
+  | { readonly type: "node_selected"; readonly nodeId: string }
+  | { readonly type: "filter_changed"; readonly filter: TopologyFilterModel }
+  | { readonly type: "viewport_changed"; readonly viewport: TopologyViewport }
+  | { readonly type: "zoom_in" }
+  | { readonly type: "zoom_out" }
+  | { readonly type: "viewport_reset" };
+
+function applyFilter(data: UiTopologyModel, filter: TopologyFilterModel): UiTopologyModel {
+  return {
+    ...data,
+    filter,
+    graph: filterTopologyGraph(data.fullGraph, filter)
+  };
+}
+
+export function createInitialTopologyGraphState(): TopologyGraphState {
+  return {
+    status: "idle",
+    data: null,
+    errorMessage: null,
+    selectedNodeId: null,
+    filter: createDefaultTopologyFilter(),
+    viewport: {
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0
+    }
+  };
+}
+
+export function topologyGraphReducer(
+  state: TopologyGraphState,
+  action: TopologyGraphAction
+): TopologyGraphState {
+  switch (action.type) {
+    case "load_started":
+      return { ...state, status: "loading", errorMessage: null };
+    case "load_succeeded": {
+      const firstNodeId = action.payload.graph.nodes[0]?.id ?? null;
+
+      return {
+        status: "ready",
+        data: action.payload,
+        errorMessage: null,
+        selectedNodeId: firstNodeId,
+        filter: action.payload.filter,
+        viewport: {
+          scale: 1,
+          offsetX: 0,
+          offsetY: 0
+        }
+      };
+    }
+    case "load_failed":
+      return { ...state, status: "error", errorMessage: action.message };
+    case "node_selected":
+      return {
+        ...state,
+        selectedNodeId: action.nodeId
+      };
+    case "filter_changed": {
+      if (!state.data) {
+        return state;
+      }
+
+      const filtered = applyFilter(state.data, action.filter);
+      const selectedNodeStillVisible = filtered.graph.nodes.some((node) => node.id === state.selectedNodeId);
+
+      return {
+        ...state,
+        data: filtered,
+        filter: action.filter,
+        selectedNodeId: selectedNodeStillVisible ? state.selectedNodeId : filtered.graph.nodes[0]?.id ?? null
+      };
+    }
+    case "viewport_changed":
+      return {
+        ...state,
+        viewport: action.viewport
+      };
+    case "zoom_in":
+      return {
+        ...state,
+        viewport: {
+          ...state.viewport,
+          scale: Math.min(1.8, Number((state.viewport.scale + 0.15).toFixed(2)))
+        }
+      };
+    case "zoom_out":
+      return {
+        ...state,
+        viewport: {
+          ...state.viewport,
+          scale: Math.max(0.65, Number((state.viewport.scale - 0.15).toFixed(2)))
+        }
+      };
+    case "viewport_reset":
+      return {
+        ...state,
+        viewport: {
+          scale: 1,
+          offsetX: 0,
+          offsetY: 0
+        }
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/network-domain/src/index.ts
+++ b/packages/network-domain/src/index.ts
@@ -78,4 +78,5 @@ export function validatePrefixHierarchyBinding(binding: PrefixHierarchyBinding):
 }
 
 export * from "./topology/index.js";
+export * from "./topology-view/index.js";
 export * from "./path-tracing/index.js";

--- a/packages/network-domain/src/topology-view/index.ts
+++ b/packages/network-domain/src/topology-view/index.ts
@@ -1,0 +1,161 @@
+import type { TopologyEdgeKind } from "../topology/index.js";
+
+export interface TopologyViewDevice {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly tone: "network" | "compute" | "power" | "storage";
+  readonly siteId: string;
+  readonly siteName: string;
+  readonly interfaceIds: readonly string[];
+  readonly vlanIds: readonly string[];
+}
+
+export interface TopologyViewCable {
+  readonly id: string;
+  readonly fromDeviceId: string;
+  readonly toDeviceId: string;
+  readonly kind: Extract<TopologyEdgeKind, "cable-link" | "l2-adjacency" | "l3-adjacency" | "vlan-propagation">;
+  readonly label: string;
+  readonly vlanIds: readonly string[];
+}
+
+export interface TopologyViewNode {
+  readonly id: string;
+  readonly label: string;
+  readonly role: string;
+  readonly siteId: string;
+  readonly siteName: string;
+  readonly tone: "network" | "compute" | "power" | "storage";
+  readonly interfaceCount: number;
+  readonly vlanIds: readonly string[];
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+  };
+}
+
+export interface TopologyViewEdge {
+  readonly id: string;
+  readonly fromNodeId: string;
+  readonly toNodeId: string;
+  readonly kind: TopologyViewCable["kind"];
+  readonly label: string;
+  readonly siteId: string;
+  readonly vlanIds: readonly string[];
+}
+
+export interface TopologyViewGraph {
+  readonly nodes: readonly TopologyViewNode[];
+  readonly edges: readonly TopologyViewEdge[];
+}
+
+export interface TopologyViewLayoutOptions {
+  readonly columnWidth: number;
+  readonly rowHeight: number;
+  readonly siteOffsetX: number;
+  readonly roleBands: readonly string[];
+}
+
+const defaultLayoutOptions: TopologyViewLayoutOptions = {
+  columnWidth: 220,
+  rowHeight: 130,
+  siteOffsetX: 520,
+  roleBands: ["Spine", "Top-of-rack switch", "Aggregation", "Application host", "Storage host", "Power distribution"]
+};
+
+function getRoleBandIndex(roleBands: readonly string[], role: string): number {
+  const index = roleBands.findIndex((band) => band === role);
+
+  return index >= 0 ? index : roleBands.length;
+}
+
+function toStableDeviceOrder(devices: readonly TopologyViewDevice[]) {
+  return [...devices].sort((left, right) => {
+    const siteComparison = left.siteName.localeCompare(right.siteName);
+
+    if (siteComparison !== 0) {
+      return siteComparison;
+    }
+
+    const roleComparison = left.role.localeCompare(right.role);
+
+    if (roleComparison !== 0) {
+      return roleComparison;
+    }
+
+    const nameComparison = left.name.localeCompare(right.name);
+
+    if (nameComparison !== 0) {
+      return nameComparison;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function createTopologyView(
+  devices: readonly TopologyViewDevice[],
+  cables: readonly TopologyViewCable[],
+  options: Partial<TopologyViewLayoutOptions> = {}
+): TopologyViewGraph {
+  const layout = { ...defaultLayoutOptions, ...options };
+  const orderedDevices = toStableDeviceOrder(devices);
+  const siteOrder = [...new Set(orderedDevices.map((device) => device.siteId))];
+  const siteColumns = new Map<string, number>();
+
+  for (const [index, siteId] of siteOrder.entries()) {
+    siteColumns.set(siteId, index);
+  }
+
+  const nodes = orderedDevices.map((device, index) => {
+    const siteColumn = siteColumns.get(device.siteId) ?? 0;
+    const bandIndex = getRoleBandIndex(layout.roleBands, device.role);
+    const peerOffset = orderedDevices
+      .slice(0, index)
+      .filter((candidate) => candidate.siteId === device.siteId && candidate.role === device.role).length;
+
+    return {
+      id: device.id,
+      label: device.name,
+      role: device.role,
+      siteId: device.siteId,
+      siteName: device.siteName,
+      tone: device.tone,
+      interfaceCount: device.interfaceIds.length,
+      vlanIds: [...device.vlanIds].sort((left, right) => left.localeCompare(right)),
+      position: {
+        x: 160 + siteColumn * layout.siteOffsetX + peerOffset * layout.columnWidth,
+        y: 120 + bandIndex * layout.rowHeight
+      }
+    } satisfies TopologyViewNode;
+  });
+  const nodeDirectory = new Map(nodes.map((node) => [node.id, node]));
+  const edges = [...cables]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .flatMap((cable) => {
+      const fromNode = nodeDirectory.get(cable.fromDeviceId);
+      const toNode = nodeDirectory.get(cable.toDeviceId);
+
+      if (!fromNode || !toNode) {
+        return [];
+      }
+
+      return [
+        {
+          id: cable.id,
+          fromNodeId: cable.fromDeviceId,
+          toNodeId: cable.toDeviceId,
+          kind: cable.kind,
+          label: cable.label,
+          siteId: fromNode.siteId === toNode.siteId ? fromNode.siteId : `${fromNode.siteId}:${toNode.siteId}`,
+          vlanIds: [...new Set(cable.vlanIds)].sort((left, right) => left.localeCompare(right))
+        } satisfies TopologyViewEdge
+      ];
+    });
+
+  return {
+    nodes,
+    edges
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -76,3 +76,4 @@ export function getNavigationItem(sectionId: string): NavigationItem {
 }
 
 export * from "./rack-system/index.js";
+export * from "./topology/index.js";

--- a/packages/ui/src/topology/index.ts
+++ b/packages/ui/src/topology/index.ts
@@ -1,0 +1,129 @@
+export type TopologyNodeTone = "network" | "compute" | "power" | "storage";
+
+export type TopologyRenderedEdgeKind =
+  | "cable-link"
+  | "l2-adjacency"
+  | "l3-adjacency"
+  | "vlan-propagation";
+
+export interface TopologyNodePosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface TopologyGraphNode {
+  readonly id: string;
+  readonly label: string;
+  readonly role: string;
+  readonly siteId: string;
+  readonly siteName: string;
+  readonly tone: TopologyNodeTone;
+  readonly interfaceCount: number;
+  readonly vlanIds: readonly string[];
+  readonly position: TopologyNodePosition;
+}
+
+export interface TopologyGraphEdge {
+  readonly id: string;
+  readonly fromNodeId: string;
+  readonly toNodeId: string;
+  readonly kind: TopologyRenderedEdgeKind;
+  readonly label: string;
+  readonly siteId: string;
+  readonly vlanIds: readonly string[];
+}
+
+export interface TopologyGraphModel {
+  readonly nodes: readonly TopologyGraphNode[];
+  readonly edges: readonly TopologyGraphEdge[];
+}
+
+export interface TopologyFilterModel {
+  readonly siteId: string | null;
+  readonly role: string | null;
+  readonly vlanId: string | null;
+}
+
+export function createDefaultTopologyFilter(): TopologyFilterModel {
+  return {
+    siteId: null,
+    role: null,
+    vlanId: null
+  };
+}
+
+export function filterTopologyGraph(
+  graph: TopologyGraphModel,
+  filter: TopologyFilterModel
+): TopologyGraphModel {
+  const visibleNodes = graph.nodes.filter((node) => {
+    if (filter.siteId && node.siteId !== filter.siteId) {
+      return false;
+    }
+
+    if (filter.role && node.role !== filter.role) {
+      return false;
+    }
+
+    if (filter.vlanId && !node.vlanIds.includes(filter.vlanId)) {
+      return false;
+    }
+
+    return true;
+  });
+  const visibleNodeIds = new Set(visibleNodes.map((node) => node.id));
+  const visibleEdges = graph.edges.filter((edge) => {
+    if (!visibleNodeIds.has(edge.fromNodeId) || !visibleNodeIds.has(edge.toNodeId)) {
+      return false;
+    }
+
+    if (filter.siteId && edge.siteId !== filter.siteId) {
+      return false;
+    }
+
+    if (filter.vlanId && !edge.vlanIds.includes(filter.vlanId)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return {
+    nodes: visibleNodes,
+    edges: visibleEdges
+  };
+}
+
+export function collectTopologyFilterOptions(graph: TopologyGraphModel) {
+  const siteOptions = [...new Map(graph.nodes.map((node) => [node.siteId, node.siteName])).entries()]
+    .map(([id, label]) => ({ id, label }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+  const roleOptions = [...new Set(graph.nodes.map((node) => node.role))].sort((left, right) =>
+    left.localeCompare(right)
+  );
+  const vlanOptions = [...new Set(graph.nodes.flatMap((node) => node.vlanIds))].sort((left, right) =>
+    left.localeCompare(right)
+  );
+
+  return {
+    sites: siteOptions,
+    roles: roleOptions,
+    vlans: vlanOptions
+  };
+}
+
+export function findTopologyNode(graph: TopologyGraphModel, nodeId: string | null) {
+  if (!nodeId) {
+    return null;
+  }
+
+  return graph.nodes.find((node) => node.id === nodeId) ?? null;
+}
+
+export function findConnectedEdges(graph: TopologyGraphModel, nodeId: string | null) {
+  if (!nodeId) {
+    return [];
+  }
+
+  return graph.edges.filter((edge) => edge.fromNodeId === nodeId || edge.toNodeId === nodeId);
+}

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -28,7 +28,9 @@ import {
   validatePrefixHierarchyBinding
 } from "../../packages/network-domain/dist/index.js";
 import {
+  createDefaultTopologyFilter,
   createRackUnitSlots,
+  filterTopologyGraph,
   getDeviceCoverageLabel,
   shellNavigation,
   workspacePanels
@@ -43,6 +45,7 @@ import {
 } from "../../packages/ipam-domain/dist/index.js";
 import { coreDomains, platformBoundaries } from "../../packages/domain-core/dist/index.js";
 import { formatBanner } from "../../packages/shared/dist/index.js";
+import { createTopologyView } from "../../packages/network-domain/dist/index.js";
 
 test("workspace metadata identifies the platform runtime", () => {
   assert.equal(workspaceMetadata.name, "InfraLynx Platform");
@@ -336,4 +339,65 @@ test("network topology and path tracing stay deterministic", () => {
   assert.equal(path.found, true);
   assert.equal(path.path.length, 2);
   assert.equal(path.path[1]?.kind, "l3-adjacency");
+});
+
+test("topology view scaffolds keep layout and filtering deterministic", () => {
+  const graph = createTopologyView(
+    [
+      {
+        id: "device-leaf-sw1",
+        name: "leaf-sw1",
+        role: "Top-of-rack switch",
+        tone: "network",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["leaf-sw1:xe-0/0/1"],
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "device-server-01",
+        name: "compute-01",
+        role: "Application host",
+        tone: "compute",
+        siteId: "site-dal1",
+        siteName: "Dallas One",
+        interfaceIds: ["compute-01:eth0"],
+        vlanIds: ["vlan-120"]
+      },
+      {
+        id: "device-server-02",
+        name: "compute-02",
+        role: "Application host",
+        tone: "compute",
+        siteId: "site-phx1",
+        siteName: "Phoenix One",
+        interfaceIds: ["compute-02:eth0"],
+        vlanIds: ["vlan-220"]
+      }
+    ],
+    [
+      {
+        id: "edge-1",
+        fromDeviceId: "device-leaf-sw1",
+        toDeviceId: "device-server-01",
+        kind: "cable-link",
+        label: "access-a",
+        vlanIds: ["vlan-120"]
+      }
+    ]
+  );
+  const filtered = filterTopologyGraph(graph, {
+    ...createDefaultTopologyFilter(),
+    siteId: "site-dal1",
+    vlanId: "vlan-120"
+  });
+  const leafNode = graph.nodes.find((node) => node.id === "device-leaf-sw1");
+  const dallasComputeNode = graph.nodes.find((node) => node.id === "device-server-01");
+
+  assert.equal(leafNode?.label, "leaf-sw1");
+  assert.equal(leafNode?.position.x, 160);
+  assert.equal((dallasComputeNode?.position.y ?? 0) > (leafNode?.position.y ?? 0), true);
+  assert.equal(filtered.nodes.length, 2);
+  assert.equal(filtered.edges.length, 1);
+  assert.equal(filtered.nodes.some((node) => node.siteId === "site-phx1"), false);
 });


### PR DESCRIPTION
## Summary
- add deterministic topology graph generation and reusable UI graph helpers
- add API-backed topology demo data plus web filters, selection, zoom, and pan
- add topology visualization tests and follow-up issues for performance and filtering

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test
- runtime smoke check for /api/topology/demo