### PR TITLE
Chunk 17: add global search and filtering system

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,9 +3,16 @@ import { pathToFileURL } from "node:url";
 
 import { workspaceMetadata } from "../../../packages/config/dist/index.js";
 import {
+  createSearchQuery,
+  getSearchDomainLabel,
+  getSearchDomainOptions,
+  groupSearchResults,
+  searchRecords,
   defaultCorePermissions,
   defaultCoreRoles,
   defaultTenantStatuses,
+  type SearchDomain,
+  type SearchRecord,
   type Tenant
 } from "../../../packages/core-domain/dist/index.js";
 import { type Rack, type Site, validateCable, validateRackPosition } from "../../../packages/dcim-domain/dist/index.js";
@@ -117,6 +124,42 @@ export interface ApiIpamTreeResponse {
   readonly guidance: readonly string[];
 }
 
+export interface ApiSearchFilterOptionResponse {
+  readonly value: SearchDomain | "all";
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface ApiSearchResultResponse {
+  readonly id: string;
+  readonly domain: SearchDomain;
+  readonly domainLabel: string;
+  readonly kind: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly location: string;
+  readonly status: string | null;
+  readonly matchedTerms: readonly string[];
+  readonly tags: readonly string[];
+  readonly score: number;
+}
+
+export interface ApiSearchResultGroupResponse {
+  readonly domain: SearchDomain;
+  readonly label: string;
+  readonly results: readonly ApiSearchResultResponse[];
+}
+
+export interface ApiSearchResponse {
+  readonly generatedAt: string;
+  readonly query: string;
+  readonly selectedDomain: SearchDomain | "all";
+  readonly totalResults: number;
+  readonly availableDomains: readonly ApiSearchFilterOptionResponse[];
+  readonly groups: readonly ApiSearchResultGroupResponse[];
+  readonly guidance: readonly string[];
+}
+
 const referenceTenants: readonly Tenant[] = [
   { id: "tenant-ops", slug: "operations", name: "Operations", status: "active" },
   { id: "tenant-net", slug: "network-engineering", name: "Network Engineering", status: "active" }
@@ -194,6 +237,202 @@ const referenceRacks: readonly Rack[] = [
   { id: "rack-a1", siteId: "site-dal1", name: "A1", totalUnits: 42 },
   { id: "rack-a2", siteId: "site-dal1", name: "A2", totalUnits: 42 }
 ] as const;
+
+function createSearchRecords(): readonly SearchRecord[] {
+  const rackResponse = createRackResponse();
+  const topologyResponse = createTopologyResponse();
+
+  return [
+    ...referenceTenants.map((tenant) => ({
+      id: tenant.id,
+      domain: "core" as const,
+      kind: "tenant",
+      title: tenant.name,
+      summary: `${tenant.name} tenant boundary with ${tenant.status} lifecycle state.`,
+      location: `Core / Tenants / ${tenant.slug}`,
+      keywords: [tenant.slug, tenant.status, "tenant"],
+      tags: ["core", "tenancy"],
+      status: tenant.status
+    })),
+    ...defaultCoreRoles.map((role) => ({
+      id: role.id,
+      domain: "core" as const,
+      kind: "role",
+      title: role.name,
+      summary: `${role.permissionIds.length} permissions assigned to ${role.slug}.`,
+      location: `Core / RBAC / ${role.slug}`,
+      keywords: [role.slug, "rbac", "role", ...role.permissionIds],
+      tags: ["core", "rbac"],
+      status: "active"
+    })),
+    ...defaultCorePermissions.map((permission) => ({
+      id: permission.id,
+      domain: "core" as const,
+      kind: "permission",
+      title: permission.id,
+      summary: `${permission.action} access on ${permission.resource}.`,
+      location: `Core / Permissions / ${permission.resource}`,
+      keywords: [permission.resource, permission.action, "permission"],
+      tags: ["core", "rbac"],
+      status: "active"
+    })),
+    ...referenceVrfs.map((vrf) => ({
+      id: vrf.id,
+      domain: "ipam" as const,
+      kind: "vrf",
+      title: vrf.name,
+      summary: `VRF ${vrf.rd ?? "unassigned"} with ${vrf.tenantId ?? "shared"} tenancy.`,
+      location: `IPAM / VRFs / ${vrf.name}`,
+      keywords: [vrf.name, vrf.rd ?? "", "vrf"],
+      tags: ["ipam", "vrf"],
+      status: "active"
+    })),
+    ...createIpamTreeResponse().prefixes.map((prefix) => ({
+      id: prefix.id,
+      domain: "ipam" as const,
+      kind: "prefix",
+      title: prefix.cidr,
+      summary: `${prefix.status} ${prefix.allocationMode} prefix in ${prefix.vrfId ?? "global"} scope.`,
+      location: `IPAM / Prefixes / ${prefix.cidr}`,
+      keywords: [prefix.cidr, prefix.status, prefix.allocationMode, prefix.vrfId ?? ""],
+      tags: ["ipam", "prefix"],
+      status: prefix.status
+    })),
+    ...referenceAddresses.map((address) => ({
+      id: address.id,
+      domain: "ipam" as const,
+      kind: "ip-address",
+      title: address.address,
+      summary: `${address.role} address bound to ${address.interfaceId ?? "unassigned interface"}.`,
+      location: `IPAM / Addresses / ${address.address}`,
+      keywords: [address.address, address.role, address.interfaceId ?? "", "ip"],
+      tags: ["ipam", "address"],
+      status: address.status
+    })),
+    ...referenceVlans.map((vlan) => ({
+      id: vlan.id,
+      domain: "ipam" as const,
+      kind: "vlan",
+      title: `${vlan.name} (VLAN ${vlan.vlanId})`,
+      summary: `${vlan.interfaceIds.length} interfaces assigned to VLAN ${vlan.vlanId}.`,
+      location: `IPAM / VLANs / ${vlan.vlanId}`,
+      keywords: [vlan.name, String(vlan.vlanId), "vlan"],
+      tags: ["ipam", "vlan"],
+      status: vlan.status
+    })),
+    ...referenceSites.map((site) => ({
+      id: site.id,
+      domain: "dcim" as const,
+      kind: "site",
+      title: site.name,
+      summary: `Physical site ${site.slug} for tenant ${site.tenantId ?? "shared"}.`,
+      location: `DCIM / Sites / ${site.slug}`,
+      keywords: [site.slug, site.name, "site"],
+      tags: ["dcim", "site"],
+      status: "active"
+    })),
+    ...referenceRacks.map((rack) => ({
+      id: rack.id,
+      domain: "dcim" as const,
+      kind: "rack",
+      title: rack.name,
+      summary: `${rack.totalUnits}U rack in site ${rack.siteId}.`,
+      location: `DCIM / Racks / ${rack.name}`,
+      keywords: [rack.name, rack.siteId, "rack", `${rack.totalUnits}u`],
+      tags: ["dcim", "rack"],
+      status: "active"
+    })),
+    ...rackResponse.rack.devices.map((device) => ({
+      id: device.id,
+      domain: "dcim" as const,
+      kind: "device",
+      title: device.name,
+      summary: `${device.role} occupying ${device.heightUnits}U starting at U${device.startUnit}.`,
+      location: `DCIM / Devices / ${device.name}`,
+      keywords: [device.name, device.role, device.tone, ...device.ports.map((port) => port.label)],
+      tags: ["dcim", "device", device.tone],
+      status: "active"
+    })),
+    ...topologyResponse.graph.nodes.map((node) => ({
+      id: node.id,
+      domain: "operations" as const,
+      kind: "topology-node",
+      title: node.label,
+      summary: `${node.role} in ${node.siteName} with ${node.interfaceCount} interfaces.`,
+      location: `Operations / Topology / ${node.siteName}`,
+      keywords: [node.label, node.role, node.siteName, ...node.vlanIds],
+      tags: ["operations", "topology"],
+      status: "live"
+    })),
+    ...topologyResponse.graph.edges.map((edge) => ({
+      id: edge.id,
+      domain: "operations" as const,
+      kind: edge.kind,
+      title: edge.label,
+      summary: `${edge.kind} relationship between ${edge.fromNodeId} and ${edge.toNodeId}.`,
+      location: `Operations / Topology / ${edge.siteId}`,
+      keywords: [edge.label, edge.kind, edge.fromNodeId, edge.toNodeId, ...edge.vlanIds],
+      tags: ["operations", "topology", edge.kind],
+      status: "live"
+    })),
+    {
+      id: "automation-job-catalog",
+      domain: "automation" as const,
+      kind: "job-catalog",
+      title: "Automation job catalog",
+      summary: "Future automation, import, export, and webhook catalog placeholder.",
+      location: "Automation / Jobs / Planned",
+      keywords: ["automation", "jobs", "webhooks", "imports", "exports"],
+      tags: ["automation", "planned"],
+      status: "planned"
+    }
+  ];
+}
+
+function createSearchResponse(queryText: string, domain: SearchDomain | "all"): ApiSearchResponse {
+  const records = createSearchRecords();
+  const query = createSearchQuery(queryText, domain);
+  const domainAgnosticMatches = searchRecords(records, createSearchQuery(queryText, "all"));
+  const matches = searchRecords(records, query);
+  const groups = groupSearchResults(matches);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    query: query.text,
+    selectedDomain: domain,
+    totalResults: matches.length,
+    availableDomains: getSearchDomainOptions().map((option) => ({
+      value: option.value,
+      label: option.label,
+      count:
+        option.value === "all"
+          ? domainAgnosticMatches.length
+          : domainAgnosticMatches.filter((match) => match.record.domain === option.value).length
+    })),
+    groups: groups.map((group) => ({
+      domain: group.domain,
+      label: group.label,
+      results: group.results.map((match) => ({
+        id: match.record.id,
+        domain: match.record.domain,
+        domainLabel: getSearchDomainLabel(match.record.domain),
+        kind: match.record.kind,
+        title: match.record.title,
+        summary: match.record.summary,
+        location: match.record.location,
+        status: match.record.status,
+        matchedTerms: match.matchedTerms,
+        tags: match.record.tags,
+        score: match.score
+      }))
+    })),
+    guidance: [
+      "Search results are generated from explicit domain records, not direct UI-side joins.",
+      "Keyword and partial-match scoring stays deterministic so future indexing can preserve behavior.",
+      "Domain filters narrow the centralized result set without changing the underlying search contract."
+    ]
+  };
+}
 
 function createRackResponse(): ApiRackResponse {
   return {
@@ -918,6 +1157,22 @@ export function handleApiRequest(request: IncomingMessage, response: ServerRespo
 
   if (request.method === "GET" && requestUrl.pathname === "/api/ipam-tree/demo") {
     sendJson(response, 200, createIpamTreeResponse());
+
+    return;
+  }
+
+  if (request.method === "GET" && requestUrl.pathname === "/api/search") {
+    const rawDomain = requestUrl.searchParams.get("domain");
+    const domain: SearchDomain | "all" =
+      rawDomain === "core" ||
+      rawDomain === "ipam" ||
+      rawDomain === "dcim" ||
+      rawDomain === "operations" ||
+      rawDomain === "automation"
+        ? rawDomain
+        : "all";
+
+    sendJson(response, 200, createSearchResponse(requestUrl.searchParams.get("q") ?? "", domain));
 
     return;
   }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,13 +1,16 @@
 import { startTransition, useDeferredValue, useEffect, useMemo, useState } from "react";
 
 import { shellNavigation, getNavigationItem, workspacePanels } from "../../../packages/ui/dist/index.js";
+import { GlobalSearch } from "./components/search/GlobalSearch.js";
 import { RackElevation } from "./components/rack/RackElevation.js";
 import { TopologyGraph } from "./components/topology/TopologyGraph.js";
 import { IpamTree } from "./components/ipam-tree/IpamTree.js";
 import { useDomainOverview } from "./hooks/use-domain-overview.js";
+import { useGlobalSearch } from "./hooks/use-global-search.js";
 import { useIpamTree } from "./hooks/use-ipam-tree.js";
 import { useRackElevation } from "./hooks/use-rack-elevation.js";
 import { useTopologyGraph } from "./hooks/use-topology-graph.js";
+import type { UiSearchResult } from "./services/search/global-search.js";
 
 function getSectionFromHash(): string {
   const hash = window.location.hash.replace(/^#/, "");
@@ -32,6 +35,7 @@ export function App() {
   const [activeSection, setActiveSection] = useState(() => getSectionFromHash());
   const deferredSection = useDeferredValue(activeSection);
   const { status, data, errorMessage, retry } = useDomainOverview();
+  const search = useGlobalSearch();
   const ipamTree = useIpamTree();
   const rack = useRackElevation();
   const topology = useTopologyGraph();
@@ -81,6 +85,14 @@ export function App() {
   const showTopologyStage =
     deferredSection === "operations" && topology.status !== "error" && topology.data !== null;
 
+  const handleSearchResultSelect = (result: UiSearchResult) => {
+    search.selectResult(result.id);
+    startTransition(() => {
+      setActiveSection(result.domain);
+    });
+    window.location.hash = result.domain;
+  };
+
   return (
     <div className="shell">
       <aside className="shell__rail">
@@ -124,6 +136,19 @@ export function App() {
             <strong>{formatSyncTime(data?.syncedAt ?? null)}</strong>
           </div>
         </header>
+
+        <GlobalSearch
+          status={search.status}
+          query={search.query}
+          selectedDomain={search.selectedDomain}
+          data={search.data}
+          errorMessage={search.errorMessage}
+          selectedResultId={search.selectedResultId}
+          onQueryChange={search.updateQuery}
+          onDomainChange={search.updateDomain}
+          onResultSelect={handleSearchResultSelect}
+          onRetry={search.retry}
+        />
 
         <section className="shell__hero" id={activeItem.id}>
           <div className="shell__hero-copy">
@@ -328,6 +353,9 @@ export function App() {
               <li key={notice}>{notice}</li>
             ))}
             {(showTopologyStage ? topology.data?.guidance ?? [] : []).map((notice) => (
+              <li key={notice}>{notice}</li>
+            ))}
+            {(search.status === "ready" ? search.data?.guidance ?? [] : []).map((notice) => (
               <li key={notice}>{notice}</li>
             ))}
           </ul>

--- a/apps/web/src/components/search/GlobalSearch.tsx
+++ b/apps/web/src/components/search/GlobalSearch.tsx
@@ -1,0 +1,167 @@
+import type { ChangeEvent } from "react";
+
+import type {
+  UiSearchDomain,
+  UiSearchFilterOption,
+  UiSearchModel,
+  UiSearchResult
+} from "../../services/search/global-search.js";
+
+export interface GlobalSearchProps {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly query: string;
+  readonly selectedDomain: UiSearchDomain | "all";
+  readonly data: UiSearchModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedResultId: string | null;
+  readonly onQueryChange: (query: string) => void;
+  readonly onDomainChange: (domain: UiSearchDomain | "all") => void;
+  readonly onResultSelect: (result: UiSearchResult) => void;
+  readonly onRetry: () => void;
+}
+
+function renderFilterOption(filter: UiSearchFilterOption) {
+  return `${filter.label} (${filter.count})`;
+}
+
+export function GlobalSearch({
+  status,
+  query,
+  selectedDomain,
+  data,
+  errorMessage,
+  selectedResultId,
+  onQueryChange,
+  onDomainChange,
+  onResultSelect,
+  onRetry
+}: GlobalSearchProps) {
+  const groups = data?.groups ?? [];
+  const hasQuery = query.trim().length > 0;
+  const totalResults = data?.totalResults ?? 0;
+
+  return (
+    <section className="shell__search" aria-label="Global search">
+      <div className="shell__search-bar">
+        <label className="shell__search-input">
+          <span className="shell__eyebrow">Global search</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => onQueryChange(event.target.value)}
+            placeholder="Search tenants, prefixes, devices, topology, VLANs"
+            aria-label="Search InfraLynx"
+          />
+        </label>
+
+        <label className="shell__search-filter">
+          <span className="shell__eyebrow">Domain filter</span>
+          <select
+            value={selectedDomain}
+            onChange={(event) => onDomainChange(event.target.value as UiSearchDomain | "all")}
+            aria-label="Filter search results by domain"
+          >
+            {(data?.filters ?? []).map((filter) => (
+              <option key={filter.value} value={filter.value}>
+                {renderFilterOption(filter)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="shell__search-summary">
+        <p className="shell__eyebrow">Search status</p>
+        <strong>
+          {!hasQuery && "Enter keywords to search across domains"}
+          {hasQuery && status === "loading" && "Searching normalized domain records"}
+          {hasQuery && status === "error" && "Search request failed"}
+          {hasQuery && status === "ready" && `${totalResults} results grouped by domain`}
+          {hasQuery && status === "idle" && "Waiting for search input"}
+        </strong>
+      </div>
+
+      {status === "error" ? (
+        <div className="shell__callout shell__callout--error">
+          <strong>Search unavailable</strong>
+          <span>{errorMessage}</span>
+          <button type="button" className="shell__button" onClick={onRetry}>
+            Retry search
+          </button>
+        </div>
+      ) : null}
+
+      {status === "loading" && hasQuery ? (
+        <div className="shell__callout">
+          <strong>Searching domain records</strong>
+          <span>InfraLynx is scoring keyword matches and regrouping them by domain.</span>
+          <div className="shell__loading-bar" aria-hidden="true" />
+        </div>
+      ) : null}
+
+      {status === "ready" && hasQuery && totalResults === 0 ? (
+        <div className="shell__search-empty">
+          <strong>No matches found</strong>
+          <p>Try a broader keyword, or switch the domain filter back to all domains.</p>
+        </div>
+      ) : null}
+
+      {groups.length > 0 ? (
+        <div className="shell__search-groups">
+          {groups.map((group) => (
+            <section key={group.domain} className="shell__search-group" aria-label={group.label}>
+              <div className="shell__search-group-header">
+                <div>
+                  <p className="shell__eyebrow">{group.label}</p>
+                  <h3>{group.count} matches</h3>
+                </div>
+              </div>
+
+              <div className="shell__search-results">
+                {group.results.map((result) => (
+                  <button
+                    key={result.id}
+                    type="button"
+                    className={
+                      result.id === selectedResultId
+                        ? "shell__search-result shell__search-result--active"
+                        : "shell__search-result"
+                    }
+                    onClick={() => onResultSelect(result)}
+                  >
+                    <div className="shell__search-result-header">
+                      <div>
+                        <span className="shell__search-kind">{result.kind}</span>
+                        <h4>{result.title}</h4>
+                      </div>
+                      <span className={`shell__status-badge shell__status-badge--${result.statusTone}`}>
+                        {result.statusLabel}
+                      </span>
+                    </div>
+                    <p>{result.summary}</p>
+                    <div className="shell__search-meta">
+                      <span>{result.location}</span>
+                      <span>Score {result.score}</span>
+                    </div>
+                    <div className="shell__search-tags">
+                      {result.matchedTerms.map((term) => (
+                        <span key={`${result.id}-${term}`} className="shell__search-tag shell__search-tag--match">
+                          {term}
+                        </span>
+                      ))}
+                      {result.tags.slice(0, 3).map((tag) => (
+                        <span key={`${result.id}-${tag}`} className="shell__search-tag">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-global-search.ts
+++ b/apps/web/src/hooks/use-global-search.ts
@@ -1,0 +1,64 @@
+import { useDeferredValue, useEffect, useReducer, useState } from "react";
+
+import {
+  fetchGlobalSearch,
+  toSearchErrorMessage,
+  type UiSearchDomain,
+  type UiSearchModel
+} from "../services/search/global-search.js";
+import {
+  createInitialGlobalSearchState,
+  globalSearchReducer
+} from "../state/global-search-state.js";
+
+export interface UseGlobalSearchResult {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly query: string;
+  readonly selectedDomain: UiSearchDomain | "all";
+  readonly data: UiSearchModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedResultId: string | null;
+  readonly updateQuery: (query: string) => void;
+  readonly updateDomain: (domain: UiSearchDomain | "all") => void;
+  readonly retry: () => void;
+  readonly selectResult: (resultId: string) => void;
+}
+
+export function useGlobalSearch(): UseGlobalSearchResult {
+  const [state, dispatch] = useReducer(globalSearchReducer, undefined, createInitialGlobalSearchState);
+  const [attempt, setAttempt] = useState(0);
+  const deferredQuery = useDeferredValue(state.query.trim());
+
+  useEffect(() => {
+    if (deferredQuery.length === 0) {
+      dispatch({ type: "search_cleared" });
+      return;
+    }
+
+    const controller = new AbortController();
+
+    dispatch({ type: "load_started" });
+
+    fetchGlobalSearch(deferredQuery, state.selectedDomain, controller.signal)
+      .then((payload) => {
+        dispatch({ type: "load_succeeded", payload });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        dispatch({ type: "load_failed", message: toSearchErrorMessage(error) });
+      });
+
+    return () => controller.abort();
+  }, [attempt, deferredQuery, state.selectedDomain]);
+
+  return {
+    ...state,
+    updateQuery: (query) => dispatch({ type: "query_changed", query }),
+    updateDomain: (domain) => dispatch({ type: "domain_changed", domain }),
+    retry: () => setAttempt((currentAttempt) => currentAttempt + 1),
+    selectResult: (resultId) => dispatch({ type: "result_selected", resultId })
+  };
+}

--- a/apps/web/src/services/search/global-search.ts
+++ b/apps/web/src/services/search/global-search.ts
@@ -1,0 +1,184 @@
+import { ApiClientError, fetchJson } from "../api-client.js";
+
+export type UiSearchDomain = "core" | "ipam" | "dcim" | "operations" | "automation";
+
+export interface ApiSearchFilterOptionResponse {
+  readonly value: UiSearchDomain | "all";
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface ApiSearchResultResponse {
+  readonly id: string;
+  readonly domain: UiSearchDomain;
+  readonly domainLabel: string;
+  readonly kind: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly location: string;
+  readonly status: string | null;
+  readonly matchedTerms: readonly string[];
+  readonly tags: readonly string[];
+  readonly score: number;
+}
+
+export interface ApiSearchResultGroupResponse {
+  readonly domain: UiSearchDomain;
+  readonly label: string;
+  readonly results: readonly ApiSearchResultResponse[];
+}
+
+export interface ApiSearchResponse {
+  readonly generatedAt: string;
+  readonly query: string;
+  readonly selectedDomain: UiSearchDomain | "all";
+  readonly totalResults: number;
+  readonly availableDomains: readonly ApiSearchFilterOptionResponse[];
+  readonly groups: readonly ApiSearchResultGroupResponse[];
+  readonly guidance: readonly string[];
+}
+
+export interface UiSearchFilterOption {
+  readonly value: UiSearchDomain | "all";
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface UiSearchResult {
+  readonly id: string;
+  readonly domain: UiSearchDomain;
+  readonly domainLabel: string;
+  readonly kind: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly location: string;
+  readonly statusLabel: string;
+  readonly statusTone: "live" | "warning" | "planned";
+  readonly matchedTerms: readonly string[];
+  readonly tags: readonly string[];
+  readonly score: number;
+}
+
+export interface UiSearchGroup {
+  readonly domain: UiSearchDomain;
+  readonly label: string;
+  readonly count: number;
+  readonly results: readonly UiSearchResult[];
+}
+
+export interface UiSearchModel {
+  readonly syncedAt: string;
+  readonly query: string;
+  readonly selectedDomain: UiSearchDomain | "all";
+  readonly totalResults: number;
+  readonly filters: readonly UiSearchFilterOption[];
+  readonly groups: readonly UiSearchGroup[];
+  readonly guidance: readonly string[];
+}
+
+function toStatusLabel(status: string | null): string {
+  if (!status) {
+    return "Reference";
+  }
+
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function toStatusTone(status: string | null): UiSearchResult["statusTone"] {
+  if (status === "planned") {
+    return "planned";
+  }
+
+  if (status === "reserved" || status === "deprecated" || status === "suspended" || status === "retired") {
+    return "warning";
+  }
+
+  return "live";
+}
+
+export function createEmptySearchModel(
+  selectedDomain: UiSearchDomain | "all" = "all",
+  query = ""
+): UiSearchModel {
+  return {
+    syncedAt: new Date(0).toISOString(),
+    query,
+    selectedDomain,
+    totalResults: 0,
+    filters: [
+      { value: "all", label: "All domains", count: 0 },
+      { value: "core", label: "Core Platform", count: 0 },
+      { value: "ipam", label: "IPAM", count: 0 },
+      { value: "dcim", label: "DCIM", count: 0 },
+      { value: "operations", label: "Operations", count: 0 },
+      { value: "automation", label: "Automation", count: 0 }
+    ],
+    groups: [],
+    guidance: [
+      "Search is ready for centralized domain queries.",
+      "Results will group by domain once the first query is entered."
+    ]
+  };
+}
+
+export function normalizeSearchResponse(payload: ApiSearchResponse): UiSearchModel {
+  return {
+    syncedAt: payload.generatedAt,
+    query: payload.query,
+    selectedDomain: payload.selectedDomain,
+    totalResults: payload.totalResults,
+    filters: payload.availableDomains.map((filter) => ({
+      value: filter.value,
+      label: filter.label,
+      count: filter.count
+    })),
+    groups: payload.groups.map((group) => ({
+      domain: group.domain,
+      label: group.label,
+      count: group.results.length,
+      results: group.results.map((result) => ({
+        id: result.id,
+        domain: result.domain,
+        domainLabel: result.domainLabel,
+        kind: result.kind,
+        title: result.title,
+        summary: result.summary,
+        location: result.location,
+        statusLabel: toStatusLabel(result.status),
+        statusTone: toStatusTone(result.status),
+        matchedTerms: result.matchedTerms,
+        tags: result.tags,
+        score: result.score
+      }))
+    })),
+    guidance: payload.guidance
+  };
+}
+
+export async function fetchGlobalSearch(
+  query: string,
+  domain: UiSearchDomain | "all",
+  signal?: AbortSignal
+): Promise<UiSearchModel> {
+  const trimmedQuery = query.trim();
+
+  if (trimmedQuery.length === 0) {
+    return createEmptySearchModel(domain, "");
+  }
+
+  const searchParams = new URLSearchParams({
+    q: trimmedQuery,
+    domain
+  });
+  const payload = await fetchJson<ApiSearchResponse>(`/api/search?${searchParams.toString()}`, signal);
+
+  return normalizeSearchResponse(payload);
+}
+
+export function toSearchErrorMessage(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.message;
+  }
+
+  return "InfraLynx was unable to assemble the global search result set.";
+}

--- a/apps/web/src/shell.css
+++ b/apps/web/src/shell.css
@@ -153,6 +153,183 @@ a {
   gap: 24px;
 }
 
+.shell__search {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  border-radius: 28px;
+  border: 1px solid rgba(57, 80, 106, 0.65);
+  background:
+    radial-gradient(circle at top right, rgba(215, 178, 109, 0.14), transparent 28%),
+    linear-gradient(135deg, rgba(23, 36, 52, 0.86), rgba(11, 18, 26, 0.92));
+  box-shadow: var(--ui-shadow);
+}
+
+.shell__search-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(240px, 0.7fr);
+  gap: 14px;
+}
+
+.shell__search-input,
+.shell__search-filter {
+  display: grid;
+  gap: 8px;
+}
+
+.shell__search input,
+.shell__search select {
+  width: 100%;
+  padding: 13px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(57, 80, 106, 0.55);
+  background: rgba(12, 19, 29, 0.62);
+  color: var(--ui-text);
+  font: inherit;
+}
+
+.shell__search input::placeholder {
+  color: rgba(185, 196, 206, 0.88);
+}
+
+.shell__search input:focus,
+.shell__search select:focus {
+  outline: 2px solid rgba(109, 166, 215, 0.52);
+  outline-offset: 2px;
+}
+
+.shell__search-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: center;
+}
+
+.shell__search-summary strong {
+  color: var(--ui-text);
+}
+
+.shell__search-empty {
+  padding: 16px 18px;
+  border-radius: 20px;
+  border: 1px dashed rgba(57, 80, 106, 0.6);
+  background: rgba(12, 19, 29, 0.4);
+}
+
+.shell__search-empty strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.shell__search-empty p {
+  margin: 0;
+  color: var(--ui-text-muted);
+}
+
+.shell__search-groups {
+  display: grid;
+  gap: 16px;
+}
+
+.shell__search-group {
+  display: grid;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(57, 80, 106, 0.35);
+}
+
+.shell__search-group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.shell__search-group-header h3 {
+  margin: 6px 0 0;
+  font-size: 1.05rem;
+}
+
+.shell__search-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.shell__search-result {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid rgba(57, 80, 106, 0.45);
+  border-radius: 20px;
+  background: rgba(12, 19, 29, 0.46);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.shell__search-result:hover,
+.shell__search-result--active {
+  transform: translateY(-2px);
+  border-color: rgba(109, 166, 215, 0.55);
+  background: rgba(16, 26, 38, 0.92);
+}
+
+.shell__search-result-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.shell__search-result-header h4 {
+  margin: 4px 0 0;
+  font-size: 1rem;
+}
+
+.shell__search-kind {
+  color: var(--ui-accent);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.shell__search-result p {
+  margin: 0;
+  color: var(--ui-text-muted);
+}
+
+.shell__search-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--ui-text-muted);
+  font-size: 0.8rem;
+}
+
+.shell__search-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.shell__search-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: rgba(57, 80, 106, 0.34);
+  color: var(--ui-text);
+  font-size: 0.76rem;
+}
+
+.shell__search-tag--match {
+  background: rgba(215, 178, 109, 0.16);
+  color: #f1d89f;
+}
+
 .shell__workspace-detail {
   display: grid;
   gap: 18px;
@@ -1078,6 +1255,10 @@ a {
     grid-template-columns: 1fr;
   }
 
+  .shell__search-bar {
+    grid-template-columns: 1fr;
+  }
+
   .shell__metric-grid {
     grid-template-columns: 1fr;
   }
@@ -1119,5 +1300,14 @@ a {
   .shell__strip,
   .shell__context {
     grid-template-columns: 1fr;
+  }
+
+  .shell__search-results {
+    grid-template-columns: 1fr;
+  }
+
+  .shell__search-summary {
+    flex-direction: column;
+    align-items: start;
   }
 }

--- a/apps/web/src/state/global-search-state.ts
+++ b/apps/web/src/state/global-search-state.ts
@@ -1,0 +1,91 @@
+import {
+  createEmptySearchModel,
+  type UiSearchDomain,
+  type UiSearchModel
+} from "../services/search/global-search.js";
+
+export interface GlobalSearchState {
+  readonly status: "idle" | "loading" | "ready" | "error";
+  readonly query: string;
+  readonly selectedDomain: UiSearchDomain | "all";
+  readonly data: UiSearchModel | null;
+  readonly errorMessage: string | null;
+  readonly selectedResultId: string | null;
+}
+
+export type GlobalSearchAction =
+  | { readonly type: "query_changed"; readonly query: string }
+  | { readonly type: "domain_changed"; readonly domain: UiSearchDomain | "all" }
+  | { readonly type: "search_cleared" }
+  | { readonly type: "load_started" }
+  | { readonly type: "load_succeeded"; readonly payload: UiSearchModel }
+  | { readonly type: "load_failed"; readonly message: string }
+  | { readonly type: "result_selected"; readonly resultId: string };
+
+function getFirstResultId(payload: UiSearchModel): string | null {
+  return payload.groups[0]?.results[0]?.id ?? null;
+}
+
+export function createInitialGlobalSearchState(): GlobalSearchState {
+  return {
+    status: "idle",
+    query: "",
+    selectedDomain: "all",
+    data: createEmptySearchModel(),
+    errorMessage: null,
+    selectedResultId: null
+  };
+}
+
+export function globalSearchReducer(
+  state: GlobalSearchState,
+  action: GlobalSearchAction
+): GlobalSearchState {
+  switch (action.type) {
+    case "query_changed":
+      return {
+        ...state,
+        query: action.query
+      };
+    case "domain_changed":
+      return {
+        ...state,
+        selectedDomain: action.domain
+      };
+    case "search_cleared":
+      return {
+        ...state,
+        status: "idle",
+        data: createEmptySearchModel(state.selectedDomain, ""),
+        errorMessage: null,
+        selectedResultId: null
+      };
+    case "load_started":
+      return {
+        ...state,
+        status: "loading",
+        errorMessage: null
+      };
+    case "load_succeeded":
+      return {
+        ...state,
+        status: "ready",
+        data: action.payload,
+        errorMessage: null,
+        selectedResultId: getFirstResultId(action.payload)
+      };
+    case "load_failed":
+      return {
+        ...state,
+        status: "error",
+        errorMessage: action.message
+      };
+    case "result_selected":
+      return {
+        ...state,
+        selectedResultId: action.resultId
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/core-domain/src/index.ts
+++ b/packages/core-domain/src/index.ts
@@ -75,3 +75,5 @@ export function createTenantDirectory(tenants: readonly Tenant[]) {
 export function createRoleIndex(roles: readonly RoleDefinition[]) {
   return new Map(roles.map((role) => [role.id, role]));
 }
+
+export * from "./search/index.js";

--- a/packages/core-domain/src/search/index.ts
+++ b/packages/core-domain/src/search/index.ts
@@ -1,0 +1,200 @@
+export type SearchDomain = "core" | "ipam" | "dcim" | "operations" | "automation";
+
+export interface SearchRecord {
+  readonly id: string;
+  readonly domain: SearchDomain;
+  readonly kind: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly location: string;
+  readonly keywords: readonly string[];
+  readonly tags: readonly string[];
+  readonly status: string | null;
+}
+
+export interface SearchQuery {
+  readonly text: string;
+  readonly tokens: readonly string[];
+  readonly domain: SearchDomain | "all";
+}
+
+export interface SearchMatch {
+  readonly record: SearchRecord;
+  readonly score: number;
+  readonly matchedTerms: readonly string[];
+}
+
+export interface SearchResultGroup {
+  readonly domain: SearchDomain;
+  readonly label: string;
+  readonly results: readonly SearchMatch[];
+}
+
+const searchDomainOrder: readonly SearchDomain[] = [
+  "core",
+  "ipam",
+  "dcim",
+  "operations",
+  "automation"
+] as const;
+
+const searchDomainLabels: Record<SearchDomain, string> = {
+  core: "Core Platform",
+  ipam: "IPAM",
+  dcim: "DCIM",
+  operations: "Operations",
+  automation: "Automation"
+};
+
+function compareSearchDomains(left: SearchDomain, right: SearchDomain): number {
+  return searchDomainOrder.indexOf(left) - searchDomainOrder.indexOf(right);
+}
+
+export function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function tokenizeSearchText(value: string): readonly string[] {
+  const normalized = normalizeSearchText(value);
+
+  return normalized.length === 0 ? [] : normalized.split(" ");
+}
+
+export function createSearchQuery(text: string, domain: SearchDomain | "all" = "all"): SearchQuery {
+  return {
+    text: normalizeSearchText(text),
+    tokens: tokenizeSearchText(text),
+    domain
+  };
+}
+
+function createSearchCorpus(record: SearchRecord): string {
+  return normalizeSearchText(
+    [
+      record.title,
+      record.summary,
+      record.location,
+      record.kind,
+      ...record.keywords,
+      ...record.tags,
+      record.status ?? ""
+    ].join(" ")
+  );
+}
+
+function scoreSearchRecord(record: SearchRecord, query: SearchQuery): SearchMatch | null {
+  if (query.domain !== "all" && record.domain !== query.domain) {
+    return null;
+  }
+
+  if (query.tokens.length === 0) {
+    return null;
+  }
+
+  const title = normalizeSearchText(record.title);
+  const summary = normalizeSearchText(record.summary);
+  const location = normalizeSearchText(record.location);
+  const corpus = createSearchCorpus(record);
+  const matchedTerms: string[] = [];
+  let score = 0;
+
+  for (const token of query.tokens) {
+    if (!corpus.includes(token)) {
+      return null;
+    }
+
+    matchedTerms.push(token);
+
+    if (title === token) {
+      score += 18;
+      continue;
+    }
+
+    if (title.startsWith(token)) {
+      score += 12;
+      continue;
+    }
+
+    if (title.includes(token)) {
+      score += 9;
+      continue;
+    }
+
+    if (location.includes(token)) {
+      score += 7;
+      continue;
+    }
+
+    if (summary.includes(token)) {
+      score += 5;
+      continue;
+    }
+
+    score += 3;
+  }
+
+  score += Math.max(0, 5 - Math.min(record.tags.length, 5));
+
+  return {
+    record,
+    score,
+    matchedTerms: [...new Set(matchedTerms)]
+  };
+}
+
+export function searchRecords(records: readonly SearchRecord[], query: SearchQuery): readonly SearchMatch[] {
+  return records
+    .map((record) => scoreSearchRecord(record, query))
+    .filter((match): match is SearchMatch => match !== null)
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return right.score - left.score;
+      }
+
+      const domainComparison = compareSearchDomains(left.record.domain, right.record.domain);
+
+      if (domainComparison !== 0) {
+        return domainComparison;
+      }
+
+      const titleComparison = left.record.title.localeCompare(right.record.title);
+
+      if (titleComparison !== 0) {
+        return titleComparison;
+      }
+
+      return left.record.id.localeCompare(right.record.id);
+    });
+}
+
+export function groupSearchResults(matches: readonly SearchMatch[]): readonly SearchResultGroup[] {
+  const grouped = new Map<SearchDomain, SearchMatch[]>();
+
+  for (const match of matches) {
+    const current = grouped.get(match.record.domain) ?? [];
+    current.push(match);
+    grouped.set(match.record.domain, current);
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => compareSearchDomains(left, right))
+    .map(([domain, results]) => ({
+      domain,
+      label: searchDomainLabels[domain],
+      results
+    }));
+}
+
+export function getSearchDomainLabel(domain: SearchDomain): string {
+  return searchDomainLabels[domain];
+}
+
+export function getSearchDomainOptions(): readonly { readonly value: SearchDomain | "all"; readonly label: string }[] {
+  return [
+    { value: "all", label: "All domains" },
+    ...searchDomainOrder.map((domain) => ({
+      value: domain,
+      label: searchDomainLabels[domain]
+    }))
+  ];
+}

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -3,10 +3,13 @@ import assert from "node:assert/strict";
 
 import { workspaceMetadata } from "../../packages/config/dist/index.js";
 import {
+  createSearchQuery,
   createRoleIndex,
   createTenantDirectory,
   defaultCoreRoles,
-  defaultTenantStatuses
+  defaultTenantStatuses,
+  groupSearchResults,
+  searchRecords
 } from "../../packages/core-domain/dist/index.js";
 import { createSession, resolveAccessDecision } from "../../packages/auth/dist/index.js";
 import { createAuditRecord, summarizeAuditRecord } from "../../packages/audit/dist/index.js";
@@ -80,6 +83,53 @@ test("core domain scaffolds expose tenant, status, and role indexes", () => {
   assert.equal(defaultTenantStatuses.length, 3);
   assert.equal(tenants.get("tenant-1")?.name, "Operations");
   assert.equal(roles.get("core-platform-admin")?.slug, "platform-admin");
+});
+
+test("core search scaffolds rank, filter, and group results deterministically", () => {
+  const records = [
+    {
+      id: "tenant-ops",
+      domain: "core",
+      kind: "tenant",
+      title: "Operations",
+      summary: "Operations tenant boundary",
+      location: "Core / Tenants / operations",
+      keywords: ["operations", "tenant"],
+      tags: ["core"],
+      status: "active"
+    },
+    {
+      id: "prefix-prod",
+      domain: "ipam",
+      kind: "prefix",
+      title: "10.40.16.0/24",
+      summary: "Production application prefix",
+      location: "IPAM / Prefixes / 10.40.16.0/24",
+      keywords: ["production", "prefix", "apps"],
+      tags: ["ipam"],
+      status: "active"
+    },
+    {
+      id: "device-leaf-sw1",
+      domain: "dcim",
+      kind: "device",
+      title: "leaf-sw1",
+      summary: "Top-of-rack switch in Dallas",
+      location: "DCIM / Devices / leaf-sw1",
+      keywords: ["leaf", "switch", "dallas"],
+      tags: ["dcim"],
+      status: "active"
+    }
+  ];
+  const allMatches = searchRecords(records, createSearchQuery("operations"));
+  const ipamMatches = searchRecords(records, createSearchQuery("production", "ipam"));
+  const grouped = groupSearchResults(searchRecords(records, createSearchQuery("10.40")));
+
+  assert.equal(allMatches[0]?.record.id, "tenant-ops");
+  assert.equal(ipamMatches.length, 1);
+  assert.equal(ipamMatches[0]?.record.domain, "ipam");
+  assert.equal(grouped[0]?.domain, "ipam");
+  assert.equal(grouped[0]?.results[0]?.record.id, "prefix-prod");
 });
 
 test("auth scaffolds resolve access from assigned roles", () => {


### PR DESCRIPTION
## Summary
- add shared search contracts, tokenization, matching, and grouping in core-domain
- add centralized /api/search record assembly across core, IPAM, DCIM, and operations
- add web search service, reducer state, grouped result UI, and domain filtering
- add tests and create follow-up issues for search performance and indexing strategy

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test
- live /api/search smoke check