### PR TITLE
Chunk 18: Global navigation refinement

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,6 +1,15 @@
 import { startTransition, useDeferredValue, useEffect, useMemo, useState } from "react";
 
-import { shellNavigation, getNavigationItem, workspacePanels } from "../../../packages/ui/dist/index.js";
+import {
+  getNavigationBreadcrumbs,
+  getNavigationGroups,
+  getNavigationRoute,
+  mapDataDomainToRouteId,
+  workspacePanels
+} from "../../../packages/ui/dist/index.js";
+import { Breadcrumbs } from "./components/navigation/Breadcrumbs.js";
+import { ContextNavigation } from "./components/navigation/ContextNavigation.js";
+import { SidebarNavigation } from "./components/navigation/SidebarNavigation.js";
 import { GlobalSearch } from "./components/search/GlobalSearch.js";
 import { RackElevation } from "./components/rack/RackElevation.js";
 import { TopologyGraph } from "./components/topology/TopologyGraph.js";
@@ -10,12 +19,22 @@ import { useGlobalSearch } from "./hooks/use-global-search.js";
 import { useIpamTree } from "./hooks/use-ipam-tree.js";
 import { useRackElevation } from "./hooks/use-rack-elevation.js";
 import { useTopologyGraph } from "./hooks/use-topology-graph.js";
+import { AppShell } from "./layout/AppShell.js";
 import type { UiSearchResult } from "./services/search/global-search.js";
 
 function getSectionFromHash(): string {
   const hash = window.location.hash.replace(/^#/, "");
+  const knownIds = new Set([
+    "overview",
+    "core",
+    "ipam",
+    "dcim",
+    "networking",
+    "virtualization",
+    "automation"
+  ]);
 
-  return shellNavigation.some((item) => item.id === hash) ? hash : "overview";
+  return knownIds.has(hash) ? hash : "overview";
 }
 
 function formatSyncTime(timestamp: string | null): string {
@@ -52,18 +71,52 @@ export function App() {
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
-  const activeItem = useMemo(() => getNavigationItem(deferredSection), [deferredSection]);
-  const navigation = shellNavigation.map((item) => ({
-    ...item,
-    active: item.id === activeSection
-  }));
+  const navigationGroups = useMemo(() => getNavigationGroups(), []);
+  const activeRoute = useMemo(() => getNavigationRoute(deferredSection), [deferredSection]);
+  const breadcrumbs = useMemo(() => getNavigationBreadcrumbs(deferredSection), [deferredSection]);
   const activeDomain = useMemo(
-    () => data?.domains.find((domain) => domain.id === deferredSection) ?? data?.domains[0] ?? null,
-    [data, deferredSection]
+    () =>
+      data?.domains.find((domain) => domain.id === activeRoute.dataDomainId) ??
+      (activeRoute.id === "overview" ? data?.domains[0] ?? null : null),
+    [activeRoute, data]
   );
-  const domainPanels = useMemo(
-    () => data?.domains.filter((domain) => domain.id !== "overview") ?? [],
-    [data]
+  const domainPanels = useMemo(() => {
+    return navigationGroups
+      .flatMap((group) => group.routes)
+      .filter((route) => route.id !== "overview")
+      .map((route) => {
+        const domain = data?.domains.find((item) => item.id === route.dataDomainId);
+
+        if (domain) {
+          return {
+            id: route.id,
+            title: route.label,
+            statusLabel: domain.statusLabel,
+            tone: domain.tone,
+            summary: domain.summary,
+            metrics: domain.metrics,
+            indicators: domain.indicators
+          };
+        }
+
+        return {
+          id: route.id,
+          title: route.label,
+          statusLabel: route.id === "virtualization" ? "Reserved" : "Planned",
+          tone: "planned" as const,
+          summary: route.summary,
+          metrics: [
+            { label: "State", value: route.id === "virtualization" ? "Reserved" : "Planned" },
+            { label: "Mode", value: "Navigation-ready" },
+            { label: "Source", value: "Shell model" }
+          ],
+          indicators: route.contextLinks.map((link) => link.label)
+        };
+      });
+  }, [data, navigationGroups]);
+  const activePanel = useMemo(
+    () => domainPanels.find((panel) => panel.id === activeRoute.id) ?? domainPanels[0] ?? null,
+    [activeRoute.id, domainPanels]
   );
   const fallbackPanels = workspacePanels.map((panel) => ({
     id: panel.id,
@@ -79,88 +132,95 @@ export function App() {
   }));
   const visiblePanels = domainPanels.length > 0 ? domainPanels : fallbackPanels;
   const showRackStage =
-    deferredSection === "dcim" && rack.status !== "error" && rack.data !== null;
+    activeRoute.id === "dcim" && rack.status !== "error" && rack.data !== null;
   const showIpamStage =
-    deferredSection === "ipam" && ipamTree.status !== "error" && ipamTree.data !== null;
+    activeRoute.id === "ipam" && ipamTree.status !== "error" && ipamTree.data !== null;
   const showTopologyStage =
-    deferredSection === "operations" && topology.status !== "error" && topology.data !== null;
+    activeRoute.id === "networking" && topology.status !== "error" && topology.data !== null;
 
   const handleSearchResultSelect = (result: UiSearchResult) => {
     search.selectResult(result.id);
+    const routeId = mapDataDomainToRouteId(result.domain);
+
     startTransition(() => {
-      setActiveSection(result.domain);
+      setActiveSection(routeId);
     });
-    window.location.hash = result.domain;
+    window.location.hash = routeId;
   };
 
   return (
-    <div className="shell">
-      <aside className="shell__rail">
-        <div className="shell__brand">
-          <span className="shell__brand-mark" />
-          <div>
-            <p>InfraLynx</p>
-            <span>Enterprise infrastructure control plane</span>
-          </div>
-        </div>
-
-        <nav className="shell__nav" aria-label="Primary">
-          {navigation.map((item) => (
-            <a
-              key={item.id}
-              href={`#${item.id}`}
-              className={item.active ? "shell__nav-link shell__nav-link--active" : "shell__nav-link"}
-              style={{ "--nav-accent": item.accent } as React.CSSProperties}
-            >
-              <span>{item.label}</span>
-              <small>{item.domain}</small>
-            </a>
-          ))}
-        </nav>
-
-        <div className="shell__rail-footer">
-          <p>Workspace state</p>
-          <strong>{status === "ready" ? "Live domain summary connected" : "Waiting for backend data"}</strong>
-        </div>
-      </aside>
-
-      <main className="shell__workspace">
-        <header className="shell__header">
-          <div>
-            <p className="shell__eyebrow">UI data integration layer</p>
-            <h1>{data?.workspaceName ?? "InfraLynx Platform"}</h1>
+    <AppShell
+      brand={
+        <>
+          <div className="shell__brand">
+            <span className="shell__brand-mark" />
+            <div>
+              <p>InfraLynx</p>
+              <span>Enterprise infrastructure control plane</span>
+            </div>
           </div>
 
-          <div className="shell__header-meta">
-            <span>Last synced</span>
-            <strong>{formatSyncTime(data?.syncedAt ?? null)}</strong>
+          <div className="shell__rail-footer">
+            <p>Workspace state</p>
+            <strong>{status === "ready" ? "Live domain summary connected" : "Waiting for backend data"}</strong>
+          </div>
+        </>
+      }
+      sidebar={<SidebarNavigation groups={navigationGroups} activeRouteId={activeRoute.id} />}
+      topbar={
+        <header className="shell__topbar">
+          <div className="shell__topbar-main">
+            <Breadcrumbs items={breadcrumbs} />
+            <div className="shell__topbar-heading">
+              <p className="shell__eyebrow">Navigation refinement</p>
+              <h1>{data?.workspaceName ?? "InfraLynx Platform"}</h1>
+            </div>
+          </div>
+
+          <div className="shell__topbar-side">
+            <div className="shell__header-meta">
+              <span>Last synced</span>
+              <strong>{formatSyncTime(data?.syncedAt ?? null)}</strong>
+            </div>
+
+            <div className="shell__topbar-actions">
+              {activeRoute.actions.map((action) => (
+                <a key={action.id} href={action.href} className="shell__action-pill">
+                  {action.label}
+                </a>
+              ))}
+            </div>
           </div>
         </header>
+      }
+      content={
+        <>
+          <div id="section-search">
+            <GlobalSearch
+              status={search.status}
+              query={search.query}
+              selectedDomain={search.selectedDomain}
+              data={search.data}
+              errorMessage={search.errorMessage}
+              selectedResultId={search.selectedResultId}
+              onQueryChange={search.updateQuery}
+              onDomainChange={search.updateDomain}
+              onResultSelect={handleSearchResultSelect}
+              onRetry={search.retry}
+            />
+          </div>
 
-        <GlobalSearch
-          status={search.status}
-          query={search.query}
-          selectedDomain={search.selectedDomain}
-          data={search.data}
-          errorMessage={search.errorMessage}
-          selectedResultId={search.selectedResultId}
-          onQueryChange={search.updateQuery}
-          onDomainChange={search.updateDomain}
-          onResultSelect={handleSearchResultSelect}
-          onRetry={search.retry}
-        />
-
-        <section className="shell__hero" id={activeItem.id}>
+          <section className="shell__hero" id="section-brief">
           <div className="shell__hero-copy">
-            <p className="shell__eyebrow">{status === "ready" ? activeItem.label : "Data status"}</p>
+            <p className="shell__eyebrow">{activeRoute.label}</p>
             <h2>
               {status === "loading" && "Synchronizing backend domain summaries."}
               {status === "error" && "Domain data is temporarily unavailable."}
-              {status === "ready" && activeDomain?.title}
+              {status === "ready" && activeRoute.label}
               {status === "idle" && "Preparing the InfraLynx workspace."}
             </h2>
             <p>
-              {status === "ready" && activeDomain?.summary}
+              {status === "ready" && (activeDomain?.summary ?? activeRoute.summary)}
               {status === "loading" &&
                 "The shell is requesting normalized domain payloads from the InfraLynx API and preparing workspace-ready view models."}
               {status === "error" && errorMessage}
@@ -189,7 +249,12 @@ export function App() {
 
           <div className="shell__hero-grid" aria-label="Domain overview">
             {visiblePanels.map((panel) => (
-              <article key={panel.id} className={`shell__panel shell__panel--${panel.tone}`}>
+              <article
+                key={panel.id}
+                className={`shell__panel shell__panel--${panel.tone} ${
+                  panel.id === activeRoute.id ? "shell__panel--active" : ""
+                }`}
+              >
                 <div className="shell__panel-header">
                   <p className="shell__panel-eyebrow">{panel.statusLabel}</p>
                   <span className={`shell__status-badge shell__status-badge--${panel.tone}`}>
@@ -214,25 +279,25 @@ export function App() {
               </article>
             ))}
           </div>
-        </section>
+          </section>
 
-        <section className="shell__strip">
+          <section className="shell__strip">
           <div>
-            <span>Data contract</span>
-            <strong>{data?.boundary ?? "Normalized UI contract pending"}</strong>
+            <span>Domain</span>
+            <strong>{activeRoute.domainLabel}</strong>
           </div>
           <div>
-            <span>Runtime</span>
-            <strong>{data?.runtime ?? "Awaiting backend metadata"}</strong>
+            <span>Hierarchy</span>
+            <strong>{breadcrumbs.map((item) => item.label).join(" / ")}</strong>
           </div>
           <div>
-            <span>Transport state</span>
-            <strong>{status === "ready" ? "Healthy fetch cycle" : status === "error" ? "Retry required" : "Loading"}</strong>
+            <span>Layout state</span>
+            <strong>{activePanel?.statusLabel ?? (status === "ready" ? "Stable" : "Loading")}</strong>
           </div>
-        </section>
+          </section>
 
-        <section className="shell__workspace-detail">
-          {ipamTree.status === "loading" && deferredSection === "ipam" ? (
+          <section className="shell__workspace-detail" id="section-workspace">
+          {ipamTree.status === "loading" && activeRoute.id === "ipam" ? (
             <div className="shell__callout">
               <strong>Loading IPAM hierarchy</strong>
               <span>Precomputing VRF groups, prefix nesting, and utilization before rendering the tree.</span>
@@ -240,7 +305,7 @@ export function App() {
             </div>
           ) : null}
 
-          {ipamTree.status === "error" && deferredSection === "ipam" ? (
+          {ipamTree.status === "error" && activeRoute.id === "ipam" ? (
             <div className="shell__callout shell__callout--error">
               <strong>IPAM hierarchy unavailable</strong>
               <span>{ipamTree.errorMessage}</span>
@@ -288,7 +353,7 @@ export function App() {
             />
           ) : null}
 
-          {topology.status === "loading" && deferredSection === "operations" ? (
+          {topology.status === "loading" && activeRoute.id === "networking" ? (
             <div className="shell__callout">
               <strong>Loading topology graph</strong>
               <span>Assembling the filtered graph model, node layout, and interactive viewport state.</span>
@@ -296,7 +361,7 @@ export function App() {
             </div>
           ) : null}
 
-          {topology.status === "error" && deferredSection === "operations" ? (
+          {topology.status === "error" && activeRoute.id === "networking" ? (
             <div className="shell__callout shell__callout--error">
               <strong>Topology visualization unavailable</strong>
               <span>{topology.errorMessage}</span>
@@ -322,16 +387,41 @@ export function App() {
               onResetViewport={topology.resetViewport}
             />
           ) : null}
-        </section>
-      </main>
+          {!showIpamStage && !showRackStage && !showTopologyStage ? (
+            <section className="shell__placeholder-stage">
+              <div className="shell__placeholder-copy">
+                <p className="shell__eyebrow">{activeRoute.domainLabel}</p>
+                <h3>{activeRoute.label}</h3>
+                <p>{activeRoute.summary}</p>
+              </div>
 
-      <aside className="shell__context">
+              <div className="shell__placeholder-grid">
+                {activeRoute.contextLinks.map((link) => (
+                  <a key={link.id} href={link.href} className="shell__placeholder-link">
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            </section>
+          ) : null}
+          </section>
+        </>
+      }
+      context={
+        <>
+        <div id="section-context">
+          <ContextNavigation
+            route={activeRoute}
+            actions={activeRoute.actions}
+            contextLinks={activeRoute.contextLinks}
+          />
+        </div>
         <section className="shell__context-block">
           <p className="shell__eyebrow">Current focus</p>
-          <h3>{activeDomain?.title ?? activeItem.label}</h3>
+          <h3>{activeRoute.label}</h3>
           <p>
             {status === "ready"
-              ? activeDomain?.summary
+              ? activeDomain?.summary ?? activeRoute.summary
               : "The context rail remains stable while service, hook, and state layers converge on a normalized UI payload."}
           </p>
         </section>
@@ -360,7 +450,8 @@ export function App() {
             ))}
           </ul>
         </section>
-      </aside>
-    </div>
+        </>
+      }
+    />
   );
 }

--- a/apps/web/src/components/navigation/Breadcrumbs.tsx
+++ b/apps/web/src/components/navigation/Breadcrumbs.tsx
@@ -1,0 +1,18 @@
+import type { NavigationBreadcrumb } from "../../../../../packages/ui/dist/index.js";
+
+export interface BreadcrumbsProps {
+  readonly items: readonly NavigationBreadcrumb[];
+}
+
+export function Breadcrumbs({ items }: BreadcrumbsProps) {
+  return (
+    <nav className="shell__breadcrumbs" aria-label="Breadcrumb">
+      {items.map((item, index) => (
+        <span key={item.id} className="shell__breadcrumb">
+          <span>{item.label}</span>
+          {index < items.length - 1 ? <small aria-hidden="true">/</small> : null}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/navigation/ContextNavigation.tsx
+++ b/apps/web/src/components/navigation/ContextNavigation.tsx
@@ -1,0 +1,42 @@
+import type {
+  NavigationAction,
+  NavigationContextLink,
+  NavigationRoute
+} from "../../../../../packages/ui/dist/index.js";
+
+export interface ContextNavigationProps {
+  readonly route: NavigationRoute;
+  readonly actions: readonly NavigationAction[];
+  readonly contextLinks: readonly NavigationContextLink[];
+}
+
+export function ContextNavigation({ route, actions, contextLinks }: ContextNavigationProps) {
+  return (
+    <>
+      <section className="shell__context-block shell__context-block--nav">
+        <p className="shell__eyebrow">Page hierarchy</p>
+        <h3>{route.label}</h3>
+        <p>{route.summary}</p>
+
+        <div className="shell__context-links">
+          {contextLinks.map((link) => (
+            <a key={link.id} href={link.href} className="shell__context-link">
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="shell__context-block shell__context-block--nav">
+        <p className="shell__eyebrow">Quick actions</p>
+        <div className="shell__action-stack">
+          {actions.map((action) => (
+            <a key={action.id} href={action.href} className="shell__action-link">
+              {action.label}
+            </a>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/components/navigation/SidebarNavigation.tsx
+++ b/apps/web/src/components/navigation/SidebarNavigation.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from "react";
+
+import type { NavigationGroup, NavigationRoute } from "../../../../../packages/ui/dist/index.js";
+
+export interface SidebarNavigationProps {
+  readonly groups: readonly NavigationGroup[];
+  readonly activeRouteId: string;
+}
+
+function isRouteActive(route: NavigationRoute, activeRouteId: string) {
+  return route.id === activeRouteId;
+}
+
+export function SidebarNavigation({ groups, activeRouteId }: SidebarNavigationProps) {
+  return (
+    <nav className="shell__nav-groups" aria-label="Primary">
+      {groups.map((group) => (
+        <section key={group.id} className="shell__nav-group" aria-label={group.label}>
+          <p className="shell__nav-group-label">{group.label}</p>
+
+          <div className="shell__nav">
+            {group.routes.map((route) => (
+              <a
+                key={route.id}
+                href={`#${route.id}`}
+                className={
+                  isRouteActive(route, activeRouteId)
+                    ? "shell__nav-link shell__nav-link--active"
+                    : "shell__nav-link"
+                }
+                style={{ "--nav-accent": route.accent } as CSSProperties}
+              >
+                <span>{route.label}</span>
+                <small>{route.domainLabel}</small>
+              </a>
+            ))}
+          </div>
+        </section>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+export interface AppShellProps {
+  readonly brand: ReactNode;
+  readonly sidebar: ReactNode;
+  readonly topbar: ReactNode;
+  readonly content: ReactNode;
+  readonly context: ReactNode;
+}
+
+export function AppShell({ brand, sidebar, topbar, content, context }: AppShellProps) {
+  return (
+    <div className="shell">
+      <aside className="shell__rail">
+        <div className="shell__rail-head">{brand}</div>
+        {sidebar}
+      </aside>
+
+      <main className="shell__workspace">
+        {topbar}
+        {content}
+      </main>
+
+      <aside className="shell__context">{context}</aside>
+    </div>
+  );
+}

--- a/apps/web/src/shell.css
+++ b/apps/web/src/shell.css
@@ -59,6 +59,11 @@ a {
   gap: 28px;
 }
 
+.shell__rail-head {
+  display: grid;
+  gap: 20px;
+}
+
 .shell__brand {
   display: flex;
   align-items: center;
@@ -95,6 +100,24 @@ a {
 .shell__nav {
   display: grid;
   gap: 10px;
+}
+
+.shell__nav-groups {
+  display: grid;
+  gap: 22px;
+}
+
+.shell__nav-group {
+  display: grid;
+  gap: 10px;
+}
+
+.shell__nav-group-label {
+  margin: 0;
+  color: rgba(185, 196, 206, 0.76);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .shell__nav-link {
@@ -151,6 +174,91 @@ a {
   padding: 32px;
   display: grid;
   gap: 24px;
+}
+
+.shell__topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: start;
+  padding: 22px 26px;
+  border-radius: 28px;
+  border: 1px solid rgba(57, 80, 106, 0.65);
+  background:
+    linear-gradient(180deg, rgba(23, 36, 52, 0.82), rgba(12, 19, 29, 0.88)),
+    radial-gradient(circle at top right, rgba(109, 166, 215, 0.12), transparent 32%);
+  box-shadow: var(--ui-shadow);
+}
+
+.shell__topbar-main,
+.shell__topbar-side {
+  display: grid;
+  gap: 14px;
+}
+
+.shell__topbar-side {
+  justify-items: end;
+}
+
+.shell__topbar-heading h1 {
+  display: block;
+  margin: 8px 0 0;
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.shell__breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  color: var(--ui-text-muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.shell__breadcrumb {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.shell__breadcrumb small {
+  color: rgba(185, 196, 206, 0.55);
+}
+
+.shell__topbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 8px;
+}
+
+.shell__action-pill,
+.shell__action-link,
+.shell__context-link,
+.shell__placeholder-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(57, 80, 106, 0.52);
+  background: rgba(12, 19, 29, 0.48);
+  color: var(--ui-text);
+  font-size: 0.82rem;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background 160ms ease;
+}
+
+.shell__action-pill:hover,
+.shell__action-link:hover,
+.shell__context-link:hover,
+.shell__placeholder-link:hover {
+  transform: translateY(-1px);
+  border-color: rgba(109, 166, 215, 0.5);
+  background: rgba(17, 28, 40, 0.82);
 }
 
 .shell__search {
@@ -426,6 +534,13 @@ a {
   border-color: rgba(215, 178, 109, 0.55);
 }
 
+.shell__panel--active {
+  border-color: rgba(109, 166, 215, 0.58);
+  background:
+    linear-gradient(135deg, rgba(109, 166, 215, 0.24), transparent 60%),
+    rgba(32, 50, 70, 0.92);
+}
+
 .shell__panel h3 {
   margin: 10px 0 8px;
   font-size: 1.2rem;
@@ -603,9 +718,47 @@ a {
   padding: 22px;
 }
 
+.shell__context-block--nav {
+  background:
+    linear-gradient(180deg, rgba(23, 36, 52, 0.82), rgba(12, 19, 29, 0.86)),
+    radial-gradient(circle at top right, rgba(215, 178, 109, 0.12), transparent 34%);
+}
+
+.shell__context-links,
+.shell__action-stack,
+.shell__placeholder-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
 .shell__context h3 {
   margin: 8px 0 12px;
   font-size: 1.4rem;
+}
+
+.shell__placeholder-stage {
+  display: grid;
+  gap: 18px;
+  padding: 26px;
+  border-radius: 28px;
+  border: 1px solid rgba(57, 80, 106, 0.65);
+  background:
+    radial-gradient(circle at top right, rgba(139, 214, 167, 0.12), transparent 30%),
+    linear-gradient(180deg, rgba(23, 36, 52, 0.8), rgba(11, 18, 26, 0.9));
+  box-shadow: var(--ui-shadow);
+}
+
+.shell__placeholder-copy h3 {
+  margin: 8px 0 10px;
+  font-size: 1.6rem;
+}
+
+.shell__placeholder-copy p:last-child {
+  max-width: 54ch;
+  margin: 0;
+  color: var(--ui-text-muted);
 }
 
 .rack-stage {
@@ -1255,6 +1408,18 @@ a {
     grid-template-columns: 1fr;
   }
 
+  .shell__topbar {
+    flex-direction: column;
+  }
+
+  .shell__topbar-side {
+    justify-items: start;
+  }
+
+  .shell__topbar-actions {
+    justify-content: start;
+  }
+
   .shell__search-bar {
     grid-template-columns: 1fr;
   }
@@ -1291,7 +1456,8 @@ a {
     padding: 18px;
   }
 
-  .shell__header {
+  .shell__header,
+  .shell__topbar {
     gap: 18px;
     align-items: start;
     flex-direction: column;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,10 +1,3 @@
-export interface NavigationItem {
-  readonly id: string;
-  readonly label: string;
-  readonly domain: string;
-  readonly accent: string;
-}
-
 export interface WorkspacePanel {
   readonly id: string;
   readonly title: string;
@@ -36,15 +29,6 @@ export const uiTokens = {
   }
 } as const;
 
-export const shellNavigation: readonly NavigationItem[] = [
-  { id: "overview", label: "Overview", domain: "program", accent: "var(--ui-accent)" },
-  { id: "core", label: "Core Platform", domain: "core", accent: "var(--ui-accent-cool)" },
-  { id: "ipam", label: "IPAM", domain: "ipam", accent: "var(--ui-accent)" },
-  { id: "dcim", label: "DCIM", domain: "dcim", accent: "var(--ui-accent-signal)" },
-  { id: "automation", label: "Automation", domain: "automation", accent: "var(--ui-accent-cool)" },
-  { id: "operations", label: "Operations", domain: "operations", accent: "var(--ui-accent)" }
-] as const;
-
 export const workspacePanels: readonly WorkspacePanel[] = [
   {
     id: "core",
@@ -69,12 +53,7 @@ export const workspacePanels: readonly WorkspacePanel[] = [
   }
 ] as const;
 
-export function getNavigationItem(sectionId: string): NavigationItem {
-  const match = shellNavigation.find((item) => item.id === sectionId);
-
-  return match ?? shellNavigation[0];
-}
-
 export * from "./rack-system/index.js";
 export * from "./topology/index.js";
 export * from "./ipam-tree/index.js";
+export * from "./navigation/index.js";

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -1,0 +1,254 @@
+export type NavigationGroupId = "platform" | "domains" | "services";
+
+export type NavigationRouteId =
+  | "overview"
+  | "core"
+  | "ipam"
+  | "dcim"
+  | "networking"
+  | "virtualization"
+  | "automation";
+
+export interface NavigationAction {
+  readonly id: string;
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface NavigationContextLink {
+  readonly id: string;
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface NavigationRoute {
+  readonly id: NavigationRouteId;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly domainLabel: string;
+  readonly group: NavigationGroupId;
+  readonly accent: string;
+  readonly summary: string;
+  readonly hierarchy: readonly string[];
+  readonly dataDomainId: string | null;
+  readonly actions: readonly NavigationAction[];
+  readonly contextLinks: readonly NavigationContextLink[];
+}
+
+export interface NavigationGroup {
+  readonly id: NavigationGroupId;
+  readonly label: string;
+  readonly routes: readonly NavigationRoute[];
+}
+
+export interface NavigationBreadcrumb {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface NavigationItem {
+  readonly id: string;
+  readonly label: string;
+  readonly domain: string;
+  readonly accent: string;
+}
+
+const navigationGroupLabels: Record<NavigationGroupId, string> = {
+  platform: "Platform",
+  domains: "Domains",
+  services: "Services"
+};
+
+export const navigationRoutes: readonly NavigationRoute[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    shortLabel: "Overview",
+    domainLabel: "Program",
+    group: "platform",
+    accent: "var(--ui-accent)",
+    summary: "Program-wide snapshot spanning control plane, data models, and visual surfaces.",
+    hierarchy: ["Workspace", "Overview"],
+    dataDomainId: "overview",
+    actions: [
+      { id: "overview-search", label: "Search", href: "#section-search" },
+      { id: "overview-brief", label: "Domain brief", href: "#section-brief" }
+    ],
+    contextLinks: [
+      { id: "overview-summary", label: "Program summary", href: "#section-brief" },
+      { id: "overview-surface", label: "Workspace surface", href: "#section-workspace" }
+    ]
+  },
+  {
+    id: "core",
+    label: "Core Platform",
+    shortLabel: "Core",
+    domainLabel: "Core",
+    group: "domains",
+    accent: "var(--ui-accent-cool)",
+    summary: "Authentication, RBAC, tenancy, status, and audit contracts that frame every domain.",
+    hierarchy: ["Domains", "Core Platform"],
+    dataDomainId: "core",
+    actions: [
+      { id: "core-summary", label: "Control plane", href: "#section-brief" },
+      { id: "core-notes", label: "Policies", href: "#section-context" }
+    ],
+    contextLinks: [
+      { id: "core-brief", label: "Core summary", href: "#section-brief" },
+      { id: "core-notes", label: "Policy notes", href: "#section-context" }
+    ]
+  },
+  {
+    id: "ipam",
+    label: "IPAM",
+    shortLabel: "IPAM",
+    domainLabel: "IPAM",
+    group: "domains",
+    accent: "var(--ui-accent)",
+    summary: "VRFs, prefixes, VLANs, utilization, and allocation hierarchy views.",
+    hierarchy: ["Domains", "IPAM"],
+    dataDomainId: "ipam",
+    actions: [
+      { id: "ipam-search", label: "Search", href: "#section-search" },
+      { id: "ipam-tree", label: "Hierarchy", href: "#section-workspace" },
+      { id: "ipam-context", label: "Utilization", href: "#section-context" }
+    ],
+    contextLinks: [
+      { id: "ipam-brief", label: "Hierarchy summary", href: "#section-brief" },
+      { id: "ipam-tree-link", label: "Prefix tree", href: "#section-workspace" },
+      { id: "ipam-guidance", label: "Validation notes", href: "#section-context" }
+    ]
+  },
+  {
+    id: "dcim",
+    label: "DCIM",
+    shortLabel: "DCIM",
+    domainLabel: "DCIM",
+    group: "domains",
+    accent: "var(--ui-accent-signal)",
+    summary: "Physical inventory, rack elevation, port inspection, and cable awareness.",
+    hierarchy: ["Domains", "DCIM"],
+    dataDomainId: "dcim",
+    actions: [
+      { id: "dcim-search", label: "Search", href: "#section-search" },
+      { id: "dcim-rack", label: "Rack view", href: "#section-workspace" },
+      { id: "dcim-context", label: "Selections", href: "#section-context" }
+    ],
+    contextLinks: [
+      { id: "dcim-brief", label: "Physical summary", href: "#section-brief" },
+      { id: "dcim-rack-link", label: "Elevation", href: "#section-workspace" },
+      { id: "dcim-detail", label: "Selected device", href: "#section-context" }
+    ]
+  },
+  {
+    id: "networking",
+    label: "Networking",
+    shortLabel: "Network",
+    domainLabel: "Networking",
+    group: "domains",
+    accent: "var(--ui-accent-cool)",
+    summary: "Topology graph, cross-domain wiring, and path-oriented operational visibility.",
+    hierarchy: ["Domains", "Networking"],
+    dataDomainId: "operations",
+    actions: [
+      { id: "network-search", label: "Search", href: "#section-search" },
+      { id: "network-graph", label: "Topology", href: "#section-workspace" },
+      { id: "network-context", label: "Selection", href: "#section-context" }
+    ],
+    contextLinks: [
+      { id: "network-brief", label: "Graph summary", href: "#section-brief" },
+      { id: "network-graph-link", label: "Graph view", href: "#section-workspace" },
+      { id: "network-detail", label: "Node detail", href: "#section-context" }
+    ]
+  },
+  {
+    id: "virtualization",
+    label: "Virtualization",
+    shortLabel: "Virtual",
+    domainLabel: "Virtualization",
+    group: "domains",
+    accent: "var(--ui-accent-signal)",
+    summary: "Planned cluster, hypervisor, and VM workflows in a reserved navigation slot.",
+    hierarchy: ["Domains", "Virtualization"],
+    dataDomainId: null,
+    actions: [
+      { id: "virtual-plan", label: "Roadmap", href: "#section-brief" },
+      { id: "virtual-surface", label: "Reserved space", href: "#section-workspace" }
+    ],
+    contextLinks: [
+      { id: "virtual-summary", label: "Planned scope", href: "#section-brief" },
+      { id: "virtual-context", label: "Future context", href: "#section-context" }
+    ]
+  },
+  {
+    id: "automation",
+    label: "Automation",
+    shortLabel: "Automation",
+    domainLabel: "Automation",
+    group: "services",
+    accent: "var(--ui-accent)",
+    summary: "Future jobs, imports, exports, and webhook-driven orchestration.",
+    hierarchy: ["Services", "Automation"],
+    dataDomainId: "automation",
+    actions: [
+      { id: "automation-search", label: "Search", href: "#section-search" },
+      { id: "automation-brief", label: "Planned workflows", href: "#section-brief" }
+    ],
+    contextLinks: [
+      { id: "automation-summary", label: "Workflow scope", href: "#section-brief" },
+      { id: "automation-context", label: "Implementation notes", href: "#section-context" }
+    ]
+  }
+] as const;
+
+export function getNavigationRoute(routeId: string): NavigationRoute {
+  const match = navigationRoutes.find((route) => route.id === routeId);
+
+  return match ?? navigationRoutes[0];
+}
+
+export function getNavigationGroups(): readonly NavigationGroup[] {
+  return (["platform", "domains", "services"] as const).map((groupId) => ({
+    id: groupId,
+    label: navigationGroupLabels[groupId],
+    routes: navigationRoutes.filter((route) => route.group === groupId)
+  }));
+}
+
+export function getNavigationBreadcrumbs(routeId: string): readonly NavigationBreadcrumb[] {
+  const route = getNavigationRoute(routeId);
+
+  return route.hierarchy.map((label, index) => ({
+    id: `${route.id}-${index}`,
+    label
+  }));
+}
+
+export function mapDataDomainToRouteId(domainId: string): NavigationRouteId {
+  if (domainId === "operations") {
+    return "networking";
+  }
+
+  if (domainId === "automation") {
+    return "automation";
+  }
+
+  if (domainId === "core" || domainId === "ipam" || domainId === "dcim") {
+    return domainId;
+  }
+
+  return "overview";
+}
+
+export const shellNavigation: readonly NavigationItem[] = navigationRoutes.map((route) => ({
+  id: route.id,
+  label: route.label,
+  domain: route.domainLabel.toLowerCase(),
+  accent: route.accent
+}));
+
+export function getNavigationItem(sectionId: string): NavigationItem {
+  const match = shellNavigation.find((item) => item.id === sectionId);
+
+  return match ?? shellNavigation[0];
+}

--- a/tests/unit/workspace.test.mjs
+++ b/tests/unit/workspace.test.mjs
@@ -31,6 +31,10 @@ import {
   validatePrefixHierarchyBinding
 } from "../../packages/network-domain/dist/index.js";
 import {
+  getNavigationBreadcrumbs,
+  getNavigationGroups,
+  getNavigationRoute,
+  mapDataDomainToRouteId,
   createInitialExpandedIpamTree,
   createIpamTreeModel,
   createDefaultTopologyFilter,
@@ -329,9 +333,21 @@ test("dcim scaffolds validate rack occupancy and cable endpoints", () => {
 });
 
 test("ui scaffolds expose navigation and workspace panels", () => {
-  assert.equal(shellNavigation.length >= 6, true);
+  assert.equal(shellNavigation.length >= 7, true);
   assert.equal(workspacePanels.some((panel) => panel.id === "dcim"), true);
   assert.equal(shellNavigation[0]?.label, "Overview");
+});
+
+test("navigation scaffolds keep hierarchy and domain mapping explicit", () => {
+  const groups = getNavigationGroups();
+  const networking = getNavigationRoute("networking");
+  const breadcrumbs = getNavigationBreadcrumbs("ipam");
+
+  assert.equal(groups.some((group) => group.id === "domains"), true);
+  assert.equal(networking.dataDomainId, "operations");
+  assert.equal(breadcrumbs[0]?.label, "Domains");
+  assert.equal(breadcrumbs[1]?.label, "IPAM");
+  assert.equal(mapDataDomainToRouteId("operations"), "networking");
 });
 
 test("rack system scaffolds create deterministic device slots", () => {


### PR DESCRIPTION
## Summary
- refine the web shell into a shared navigation model with grouped sidebar routes, breadcrumbs, and context-aware actions
- move navigation contracts into the shared UI package and keep route-to-domain mapping explicit
- add follow-up issues for navigation consistency and usability tuning

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test